### PR TITLE
docs: correct health-probe routes and note their auth bypass

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -126,6 +126,8 @@ Clients can send the key in any of these headers:
 
 Leave `API_KEY` empty or unset to allow all requests without authentication.
 
+The health-probe routes (`/healthz`, `/readyz`, `/livez`) are the one exception — they stay reachable without a key so orchestrators can poll them. See **🏥 Performance & Health Probes** below.
+
 </details>
 
 <details>
@@ -243,12 +245,17 @@ The `X-User-Id` and `X-User-Email` headers are automatically populated by LibreC
 <details>
 <summary><strong>🏥 Performance & Health Probes</strong></summary>
 
-The server exposes health-check endpoints that Kubernetes (or any orchestrator) can use for liveness/readiness probes:
+The server exposes health-check endpoints that Kubernetes (or any orchestrator) can use for startup/readiness/liveness probes. Each returns `200` with a short plain-text body:
 
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /health` | Basic liveness check |
-| `GET /readiness` | Readiness check |
+| Endpoint | Probe | Body |
+|----------|-------|------|
+| `GET /healthz` | `startupProbe` — the pod has started | `ok` |
+| `GET /readyz` | `readinessProbe` — the pod can receive traffic | `ready` |
+| `GET /livez` | `livenessProbe` — the event loop is responsive; restart on failure | `alive` |
+
+> **These three routes are not protected by `API_KEY`.** They are registered at the Starlette layer (via FastMCP's `@custom_route`), so they sit outside the MCP middleware stack and deliberately bypass the API-key check described under **🔐 Authentication** above — this lets kubelet poll them without credentials. They expose no data beyond the static strings above.
+
+Use HTTP probes rather than TCP ones: a TCP probe only proves the socket still accepts connections, so a wedged Python process with a bound listener would never be restarted. An HTTP probe forces the application itself to answer.
 
 **Thread-pool offloading:** By default (`RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED=true`), all blocking document-generation work is dispatched to a bounded thread pool (`RUN_BLOCKING_MAX_WORKERS` threads, default 4). This keeps the asyncio event loop free to respond to health probes and handle concurrent requests — critical for Kubernetes deployments where blocked probes lead to pod restarts.
 


### PR DESCRIPTION
## Summary

The README's Performance & Health Probes section documented `GET /health` and `GET /readiness`. Neither path is registered anywhere in the codebase. The real routes are `/healthz`, `/readyz` and `/livez` (`main.py:86-101`), and `/livez` — the liveness probe that triggers pod restarts — was missing from the docs entirely.

## Changes

- Replace the endpoint table with the three actual routes, each with its Kubernetes probe role (`startupProbe` / `readinessProbe` / `livenessProbe`) and plain-text response body.
- Document that these routes bypass the API-key middleware: they are registered at the Starlette layer via FastMCP's `@custom_route`, so they sit outside the MCP middleware stack and kubelet can poll them without credentials. Note that they expose nothing beyond the static strings.
- Carry over the code's rationale for HTTP over TCP probes ("alive port, dead process").
- Add a matching caveat under **Authentication**, which previously promised an API key was required for *all* requests.

Cross-references use bold section names rather than anchor links, since both sections are `<summary>` elements inside `<details>` and have no heading anchors.

## Test plan

Documentation only — no code changes. Endpoint paths and response bodies verified against `main.py:86-101`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)