### PR TITLE
fix: LibreChat-merge fallout — template UUID prefix, upload thread-offload, eager httpx import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ main.py                  ← Registers all MCP tools on a single FastMCP instanc
 - When `True`: adds an 8-character UUID prefix for server-side uniqueness (e.g., `ff8ae81d_My_Report.docx`).
 - When `False`: filenames are clean without UUID prefix (e.g., `My_Report.docx`).
 - **Implementation**: The parameter flows through `upload_file_async()` → `upload_file()` → `generate_named_object_name()` in `upload_tools/`. When the parameter is `None` (not explicitly set), the default is resolved based on the storage strategy.
-- **Dynamic tools**: YAML-defined tools can include `add_unique_prefix` in their payload; the parameter is extracted with `.get("add_unique_prefix", False)` in `dynamic_docx_tools.py` and `dynamic_email_tools.py`. For dynamic tools using traditional backends, consider passing `True` explicitly if filename uniqueness is required.
+- **Dynamic tools**: YAML-defined tools may declare `add_unique_prefix` as an argument. `dynamic_docx_tools.py` and `dynamic_email_tools.py` read it with `.get("add_unique_prefix")` — deliberately **without** a default — so a template that does not declare it yields `None` and inherits the strategy-based default, exactly like the static tools. Do not reintroduce a `False` default there: the payload is built solely from the template's declared args, so `False` would reach `upload_file()` for every template, satisfy its `is None` guard, and silently suppress the prefix on every backend.
 
 ## Adding a New Document Tool
 

--- a/Readme.md
+++ b/Readme.md
@@ -49,7 +49,7 @@ Just ask your AI to _"create a sales presentation"_ or _"draft a welcome email"_
 
 All tools accept an optional **`file_name`** parameter. When provided, the output file will use that name (without extension) instead of a randomly generated identifier.
 
-All tools also accept an optional **`add_unique_prefix`** parameter (default `false`). When `false`, filenames are clean without UUID prefix (e.g., `My_Report.docx`). When `true`, adds an 8-character UUID prefix for server-side uniqueness (e.g., `ff8ae81d_My_Report.docx`). In most cases, the default is sufficient because LibreChat adds its own UUID prefix during file storage.
+All tools also accept an optional **`add_unique_prefix`** parameter. Left unset, it follows the storage backend: `true` for `LOCAL`/`S3`/`GCS`/`AZURE`/`MINIO`, where an 8-character UUID prefix prevents collisions in shared storage (e.g., `ff8ae81d_My_Report.docx`), and `false` for LibreChat, which adds its own UUID prefix during file storage. Set it explicitly to override — `false` gives clean filenames (e.g., `My_Report.docx`).
 
 **Bonus — Dynamic Templates:**
 

--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -756,7 +756,11 @@ def _register_single_template(mcp: FastMCP, spec: Dict[str, Any],
                         buffer,
                         "docx",
                         filename=payload.get("file_name") or _name,
-                        add_unique_prefix=payload.get("add_unique_prefix", False),
+                        # Absent → None, so upload_file() applies the
+                        # strategy-based default (prefix on for LOCAL/S3/GCS/
+                        # AZURE/MINIO, off for LIBRECHAT). Passing False here
+                        # would pin every template upload to "no prefix".
+                        add_unique_prefix=payload.get("add_unique_prefix"),
                     )
                 finally:
                     buffer.close()

--- a/email_tools/dynamic_email_tools.py
+++ b/email_tools/dynamic_email_tools.py
@@ -221,7 +221,10 @@ def _register_single_email_template(mcp: FastMCP, spec: Dict[str, Any]) -> bool:
                         buffer,
                         "eml",
                         filename=safe_payload.get("file_name") or safe_payload.get("subject") or _name,
-                        add_unique_prefix=safe_payload.get("add_unique_prefix", False),
+                        # Absent → None, so upload_file() applies the
+                        # strategy-based default rather than pinning every
+                        # template upload to "no prefix". See dynamic_docx_tools.
+                        add_unique_prefix=safe_payload.get("add_unique_prefix"),
                     )
                     metrics.record_call("email", _name)
                     return result

--- a/librechat_integration.py
+++ b/librechat_integration.py
@@ -8,8 +8,14 @@ import io
 import logging
 from typing import Optional, Union
 
+from async_runner import run_blocking
 from upload_tools import upload_file_async, is_librechat_strategy
-from upload_tools.backends.librechat import format_file_artifact
+
+# NOTE: upload_tools.backends.librechat is imported lazily inside the LIBRECHAT
+# branch below, not here. It pulls in httpx, and this module is imported by
+# main.py on every startup — an eager import would make an optional backend's
+# dependency mandatory for all strategies. The other backends follow the same
+# rule (see the boto3 comment in upload_tools/backends/s3.py).
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +95,8 @@ async def upload_and_format_response(
         str (URL) for traditional backends, or dict (file artifact) for LIBRECHAT
     """
     if is_librechat_strategy():
+        from upload_tools.backends.librechat import format_file_artifact
+
         # Validate user context for LIBRECHAT
         if not user_context.get("user_id"):
             raise ValueError(
@@ -108,6 +116,23 @@ async def upload_and_format_response(
         # Format as MCP file artifact
         return format_file_artifact(file_info, success_message)
     else:
-        # Traditional upload - returns URL string
+        # Traditional upload - returns URL string.
+        #
+        # upload_file() is synchronous and the backends behind it block: boto3
+        # /GCS/Azure do a network round-trip plus a signed-URL call, LOCAL hits
+        # the disk. Calling it inline here would freeze the event loop for that
+        # whole duration — no other request served, health probes included, the
+        # exact EKS failure mode async_runner.py exists to prevent. Dispatch it
+        # the same way the document build itself is dispatched.
+        #
+        # The dynamic template tools do NOT come through here: they call
+        # upload_file() from inside their own run_blocking'd body, so they are
+        # already off the loop and must not be double-dispatched.
         from upload_tools import upload_file
-        return upload_file(file_buffer, suffix, filename=filename, add_unique_prefix=add_unique_prefix)
+        return await run_blocking(
+            upload_file,
+            file_buffer,
+            suffix,
+            filename=filename,
+            add_unique_prefix=add_unique_prefix,
+        )

--- a/pptx_tools/base_pptx_tool.py
+++ b/pptx_tools/base_pptx_tool.py
@@ -1,3 +1,4 @@
+import io
 import logging
 from typing import List, Dict, Any, Optional
 
@@ -5,9 +6,6 @@ from upload_tools import upload_file
 from .slide_builder import PowerpointPresentation
 
 logger = logging.getLogger(__name__)
-
-
-import io
 
 
 def _create_presentation_buffer(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pystache>=0.6.5
 google-cloud-storage>=2.18.2
 azure-storage-blob>=12.23.1
 requests>=2.31.0
+httpx>=0.27.0
 defusedxml>=0.7.1
 python-dotenv>=1.2.1
 python-fasthtml>=0.12.0

--- a/tests/test_run_blocking.py
+++ b/tests/test_run_blocking.py
@@ -56,7 +56,10 @@ def _reload_main_with_flag(flag_value: str, max_workers: str | None = None):
       - config re-reads the environment,
       - async_runner re-binds get_config and recreates the bounded
         ThreadPoolExecutor with the freshly loaded max_workers,
-      - main re-binds run_blocking to the new async_runner module.
+      - main re-binds run_blocking to the new async_runner module,
+      - librechat_integration (which main imports, and which dispatches the
+        upload half of every static tool) re-binds it too, instead of holding
+        a run_blocking from a previous reload's async_runner.
 
     Returns the freshly imported main module.
     """
@@ -64,7 +67,7 @@ def _reload_main_with_flag(flag_value: str, max_workers: str | None = None):
     os.environ["RUN_BLOCKING_MAX_WORKERS"] = "" if max_workers is None else max_workers
     os.environ.setdefault("UPLOAD_STRATEGY", "LOCAL")
 
-    for mod_name in ("main", "async_runner", "config"):
+    for mod_name in ("main", "librechat_integration", "async_runner", "config"):
         sys.modules.pop(mod_name, None)
 
     # Defensively reset the config singleton before main reads it.
@@ -299,6 +302,67 @@ class TestDynamicToolsUseRunBlocking:
         assert inspect.iscoroutinefunction(docx_rb)
         assert inspect.iscoroutinefunction(email_rb)
         assert main.config.run_blocking_by_asyncio_thread_enabled is expected_mode
+
+
+class TestUploadUsesRunBlocking:
+    """The upload half of a static tool must be offloaded, not just the build.
+
+    The five static tools used to hand the whole job — build *and* upload — to
+    run_blocking. Splitting the buffer build out for LibreChat left
+    upload_and_format_response() calling the synchronous backend inline, so a
+    boto3 upload plus its signed-URL round-trip ran on the event loop: the very
+    stall this module exists to prevent, and one that takes the health probes
+    down with it. These tests pin the dispatch by thread identity rather than
+    by timing, so they cannot go flaky on a loaded CI box.
+    """
+
+    @staticmethod
+    def _thread_running_the_upload(flag: str) -> str:
+        """Return the thread name the storage backend executed on."""
+        import io
+        from unittest.mock import patch
+
+        _reload_main_with_flag(flag)
+
+        from config import StorageStrategy
+        from librechat_integration import upload_and_format_response
+
+        observed: list[str] = []
+
+        def record_backend(file_object, object_name):
+            observed.append(threading.current_thread().name)
+            return f"http://example.com/{object_name}"
+
+        with patch("upload_tools.main.UPLOAD_STRATEGY", StorageStrategy.LOCAL), \
+             patch("upload_tools.main.upload_to_local_folder", record_backend), \
+             patch("librechat_integration.is_librechat_strategy", return_value=False):
+            asyncio.run(
+                upload_and_format_response(
+                    io.BytesIO(b"content"), "docx", "probe",
+                    {"user_id": None}, "created",
+                )
+            )
+
+        assert observed, "storage backend never ran"
+        return observed[0]
+
+    def test_upload_runs_on_worker_thread_when_enabled(self):
+        """Flag on: the blocking backend call leaves the event loop."""
+        thread_name = self._thread_running_the_upload("true")
+
+        assert thread_name.startswith("run_blocking"), (
+            f"upload ran on {thread_name!r}, not a bounded-executor worker. "
+            f"A synchronous S3/GCS/Azure upload on the loop thread freezes "
+            f"every other request, health probes included."
+        )
+
+    def test_upload_runs_inline_when_disabled(self):
+        """Flag off: dispatch follows the same legacy path as the build."""
+        thread_name = self._thread_running_the_upload("false")
+
+        assert not thread_name.startswith("run_blocking"), (
+            f"inline mode must not touch the bounded executor; saw {thread_name!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_upload_unique_prefix.py
+++ b/tests/test_upload_unique_prefix.py
@@ -341,6 +341,125 @@ class TestToolHandlerIntegration:
             assert all(c in "0123456789abcdef" for c in prefix), f"Prefix not hex: {prefix}"
 
 
+class TestDynamicTemplateToolDefaults:
+    """Template-driven tools must inherit the strategy-based default too.
+
+    Regression: both dynamic call sites read the flag as
+    ``payload.get("add_unique_prefix", False)``. Since the payload is built
+    solely from the template's declared ``args``, a template that does not
+    declare that arg produced an explicit ``False`` — which satisfies the
+    ``is None`` check in upload_file() and pinned every template upload to
+    "no prefix" on every backend, S3 included. Reading it without a default
+    yields None, so the strategy resolution runs as it does for the static
+    tools in main.py.
+    """
+
+    DOCX_SPEC = {
+        "name": "prefix_probe_docx",
+        "description": "prefix probe",
+        "docx_path": "default_docx_template.docx",
+        "args": [
+            {"name": "req_arg", "type": "string", "required": True, "description": "Required arg"},
+        ],
+    }
+
+    EMAIL_SPEC = {
+        "name": "prefix_probe_email",
+        "description": "prefix probe",
+        "html_path": "default_email_template.html",
+        "args": [
+            {"name": "subject", "type": "string", "required": True, "description": "Subject"},
+        ],
+    }
+
+    @staticmethod
+    def _register(register, spec):
+        """Register *spec* on a throwaway server and return the live tool."""
+        import asyncio
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("prefix-test")
+        assert register(mcp, spec), f"registration failed for {spec['name']}"
+        return asyncio.run(mcp.get_tool(spec["name"]))
+
+    @staticmethod
+    def _call(tool, args):
+        import asyncio
+
+        return asyncio.run(tool.run({"data": args}))
+
+    def test_docx_template_tool_passes_none_not_false(self):
+        """A template without the arg must reach upload_file() with None."""
+        from docx_tools.dynamic_docx_tools import register_docx_template
+
+        tool = self._register(register_docx_template, self.DOCX_SPEC)
+
+        with patch("docx_tools.dynamic_docx_tools.upload_file") as mock_upload:
+            mock_upload.return_value = "http://example.com/result.docx"
+            self._call(tool, {"req_arg": "hello"})
+
+        assert mock_upload.call_args.kwargs["add_unique_prefix"] is None, \
+            "explicit False here defeats the strategy-based default in upload_file()"
+
+    def test_email_template_tool_passes_none_not_false(self):
+        """Same contract for the dynamic email tools."""
+        from email_tools.dynamic_email_tools import register_email_template
+
+        tool = self._register(register_email_template, self.EMAIL_SPEC)
+
+        with patch("email_tools.dynamic_email_tools.upload_file") as mock_upload:
+            mock_upload.return_value = "http://example.com/result.eml"
+            self._call(tool, {"subject": "hello"})
+
+        assert mock_upload.call_args.kwargs["add_unique_prefix"] is None, \
+            "explicit False here defeats the strategy-based default in upload_file()"
+
+    def test_docx_template_tool_gets_uuid_prefix_on_s3(self):
+        """End-to-end: the S3 object key carries the 8-char UUID prefix.
+
+        This is the user-visible symptom the regression produced — template
+        output landing in the bucket under a bare, collision-prone key.
+        """
+        from config import StorageStrategy
+        from docx_tools.dynamic_docx_tools import register_docx_template
+
+        tool = self._register(register_docx_template, self.DOCX_SPEC)
+
+        with patch("upload_tools.main.UPLOAD_STRATEGY", StorageStrategy.S3), \
+             patch("upload_tools.main.upload_to_s3") as mock_upload, \
+             patch("upload_tools.main.cfg") as mock_cfg:
+            mock_upload.return_value = "https://s3.example.com/file.docx"
+            mock_cfg.storage.s3 = MagicMock()
+            self._call(tool, {"req_arg": "hello"})
+
+        object_name = mock_upload.call_args[0][1]
+        assert object_name.endswith("_prefix_probe_docx.docx"), \
+            f"Expected UUID prefix for S3, got: {object_name}"
+        prefix = object_name.split("_")[0]
+        assert len(prefix) == 8, f"Expected 8-char prefix, got: {prefix}"
+        assert all(c in "0123456789abcdef" for c in prefix), f"Prefix not hex: {prefix}"
+
+    def test_template_can_still_opt_out_explicitly(self):
+        """A template that declares the arg keeps full control of the flag."""
+        from docx_tools.dynamic_docx_tools import register_docx_template
+
+        spec = dict(
+            self.DOCX_SPEC,
+            name="prefix_optout_docx",
+            args=self.DOCX_SPEC["args"] + [
+                {"name": "add_unique_prefix", "type": "bool", "required": False,
+                 "default": False, "description": "Opt out of the UUID prefix"},
+            ],
+        )
+        tool = self._register(register_docx_template, spec)
+
+        with patch("docx_tools.dynamic_docx_tools.upload_file") as mock_upload:
+            mock_upload.return_value = "http://example.com/result.docx"
+            self._call(tool, {"req_arg": "hello"})
+
+        assert mock_upload.call_args.kwargs["add_unique_prefix"] is False
+
+
 class TestToolSignatureDefaults:
     """Tests that verify the actual FastMCP tool handler signatures have correct defaults.
     


### PR DESCRIPTION
Four regressions traceable to the LibreChat merge (#86). Two commits: the prefix fix that prompted the investigation, and three further findings from auditing the rest of that merge.

---

## 1. Template-generated uploads lost their UUID prefix

Documents produced by the **template-driven tools** stopped getting the 8-char UUID filename prefix, on every storage backend (reported on S3 in production). The static `create_*` tools in `main.py` were unaffected.

Both dynamic call sites read the flag with a `False` fallback:

```python
add_unique_prefix=payload.get("add_unique_prefix", False)
```

The payload is built solely from the template's declared `args` (`dynamic_docx_tools.py:667-710`), so a template that doesn't declare that arg — i.e. essentially all of them — yields an explicit `False`. That satisfies the `is None` guard in `upload_file()` and skips the strategy resolution outright:

```python
if add_unique_prefix is None:                              # upload_tools/main.py:73
    add_unique_prefix = UPLOAD_STRATEGY != StorageStrategy.LIBRECHAT
```

Result: template output landed under bare, collision-prone object keys.

**Origin.** Fallout from `1d13b0c`, which made the prefix opt-in with a default of `False`. `09d0127` and `b9c9c15` restored the strategy-based default for `upload_file()`/`upload_file_async()` and the five static handlers a week later, but the dynamic tools were never updated. `v3.23` is the first release carrying the regression — `v3.22` and earlier always prefixed.

**Fix.** Read the flag without a default, so an absent arg yields `None` and the strategy resolution runs. A template that *declares* `add_unique_prefix` keeps full control of it.

## 2. Upload no longer ran off the event loop

The five static tools used to hand build **and** upload to `run_blocking`. Splitting the buffer build out for LibreChat left `upload_and_format_response()` calling the synchronous backend inline, so a boto3 upload plus its signed-URL round-trip executed on the asyncio loop — the exact stall `async_runner.py:1-24` exists to prevent, and it takes the health probes down with it.

Measured with a 500 ms stand-in backend and a 10 ms heartbeat:

```
before: max event-loop stall = 517 ms
after:  max event-loop stall =  24 ms
```

Dispatched through `run_blocking`. The dynamic template tools already upload from inside their own `run_blocking`'d body and are deliberately left alone — routing them through this path too would double-dispatch.

## 3. `httpx` imported on every start, undeclared

`librechat_integration` imported `format_file_artifact` at module scope, so `import main` pulled in the LibreChat backend — and `httpx` — regardless of strategy. It was not in `requirements.txt`, resolving only because `fastmcp` happens to pull it in.

Now imported lazily inside the LIBRECHAT branch, as `upload_tools/main.py:161` already does for `upload_to_librechat`, and declared in `requirements.txt` — every other optional backend is declared there despite being lazily imported.

## 4. Repo's only lint error

`import io` sat below the logger in `base_pptx_tool.py` → ruff `E402`, a gate `deploy.ps1` exits on. Moved to the top; `ruff check .` is clean.

---

## Test plan

`tests/test_upload_unique_prefix.py` had no coverage of the dynamic path at all. Added `TestDynamicTemplateToolDefaults`, which registers real template tools on a throwaway `FastMCP` instance and invokes them:

- docx template tool reaches `upload_file()` with `None`, not `False`
- same for the email template tool
- end-to-end under S3: the key passed to `upload_to_s3` carries the 8-char hex prefix
- a template declaring `add_unique_prefix` with a `False` default still opts out

The first three fail against the unfixed source — #3 with `Expected UUID prefix for S3, got: prefix_probe_docx.docx`, the exact production symptom.

Added `TestUploadUsesRunBlocking` to `tests/test_run_blocking.py` for finding 2, asserting by **thread identity** rather than timing so it cannot go flaky under CI load: flag on → the backend runs on a `run_blocking_*` worker; flag off → it does not. The first case fails against the unfixed source with `upload ran on 'MainThread'`. `_reload_main_with_flag` now also drops `librechat_integration`, which would otherwise keep a `run_blocking` bound to a previous reload's `async_runner` and ignore the flag.

**Suite:** `876 passed`, `ruff check .` clean. The 15 `tests/test_admin_app.py` failures/errors (`ModuleNotFoundError: No module named 'fasthtml'`) are a local venv gap, pre-existing on `master` and unrelated — verified by stashing these edits and re-running.

## Known, deferred

Template-driven tools fail outright under `UPLOAD_STRATEGY=LIBRECHAT` — they call the sync `upload_file()`, which raises `LIBRECHAT strategy requires async upload` (`upload_tools/main.py:76-79`). Fixing it needs an async upload path plus request-context access in the dynamic tools. Deferred: the LibreChat backend is not in use yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)