### PR TITLE
security: block image downloads to non-public addresses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,21 @@ RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED=
 # executor instead of fanning out and starving each other.
 RUN_BLOCKING_MAX_WORKERS=
 
+# --- External image downloads (SSRF protection) ---
+# Tools that embed an image from a URL resolve the host first and refuse any
+# address that is not publicly routable (loopback, RFC 1918 private ranges,
+# link-local incl. the 169.254.169.254 cloud-metadata address, CGNAT and
+# reserved ranges). Every redirect hop is re-checked.
+#
+# Default (empty / false): only public addresses may be fetched. Keep this in
+# any deployment reachable by untrusted callers.
+#
+# Truthy ("1" / "true" / "yes" / "on"): allow private and loopback targets.
+# Set this ONLY when images are legitimately served from inside your network
+# (a sibling service in-cluster, an internal MinIO endpoint, an intranet image
+# host). It removes the protection entirely, so do not enable it broadly.
+SSRF_ALLOW_PRIVATE_ADDRESSES=
+
 # --- Streamable-HTTP session mode ---
 # Default (empty / "false" / "0" / "no" / "off"): STATEFUL.
 #   Each MCP client gets an Mcp-Session-Id minted by the server and that

--- a/config.py
+++ b/config.py
@@ -360,6 +360,19 @@ class Config(BaseModel):
             "RUN_BLOCKING_MAX_WORKERS environment variable."
         ),
     )
+    allow_private_image_addresses: bool = Field(
+        default=False,
+        description=(
+            "When True, image downloads may target private, loopback and "
+            "link-local addresses. Needed only when images are served from "
+            "inside the cluster or an intranet (e.g. a sibling service or a "
+            "MinIO endpoint reachable only on the internal network). Leave "
+            "False in any deployment reachable by untrusted callers: it is "
+            "what stops a caller-supplied image URL from being used to probe "
+            "internal services or cloud-metadata endpoints. Toggled via the "
+            "SSRF_ALLOW_PRIVATE_ADDRESSES environment variable."
+        ),
+    )
     stateless_http: bool = Field(
         default=False,
         description=(
@@ -512,6 +525,9 @@ class Config(BaseModel):
                 admin=admin_settings,
                 run_blocking_by_asyncio_thread_enabled=run_blocking_by_asyncio_thread_enabled,
                 run_blocking_max_workers=run_blocking_max_workers,
+                allow_private_image_addresses=cls._parse_bool(
+                    os.environ.get("SSRF_ALLOW_PRIVATE_ADDRESSES")
+                ),
                 stateless_http=stateless_http,
             )
         except ValidationError as e:

--- a/pptx_tools/image_utils.py
+++ b/pptx_tools/image_utils.py
@@ -12,6 +12,7 @@ import io
 import ipaddress
 import logging
 import socket
+import time
 from typing import Tuple
 from urllib.parse import urljoin, urlparse
 
@@ -138,13 +139,25 @@ def _get_following_redirects(url: str) -> requests.Response:
 
     Redirects are followed manually because ``requests`` would otherwise
     follow them without giving us a chance to check where they lead.
+
+    ``REQUEST_TIMEOUT`` budgets the whole chain rather than each hop, so a
+    server cannot hold a worker thread for a multiple of it by chaining slow
+    redirects. Tool handlers run on a small bounded thread pool (see
+    RUN_BLOCKING_MAX_WORKERS), so that multiple matters.
     """
     assert_url_is_public(url)
+    deadline = time.monotonic() + REQUEST_TIMEOUT
 
     for _ in range(MAX_REDIRECTS + 1):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise requests.exceptions.Timeout(
+                f"Timed out following redirects for {url}"
+            )
+
         response = requests.get(
             url,
-            timeout=REQUEST_TIMEOUT,
+            timeout=remaining,
             stream=True,
             allow_redirects=False,
             headers={
@@ -156,6 +169,10 @@ def _get_following_redirects(url: str) -> requests.Response:
             return response
 
         location = response.headers.get('Location')
+        # Nothing reads a 3xx body. requests.get() closes its own session, so
+        # this is belt-and-braces rather than a fix for an observed leak, but
+        # it keeps the intent explicit if this ever moves to a shared Session.
+        response.close()
         if not location:
             raise ImageDownloadError(f"Redirect without Location header from {url}")
         url = urljoin(url, location)

--- a/pptx_tools/image_utils.py
+++ b/pptx_tools/image_utils.py
@@ -2,14 +2,22 @@
 
 This module provides functionality to download and validate images from URLs
 for embedding in PowerPoint slides.
+
+Downloads are restricted to publicly routable addresses (see
+:func:`assert_url_is_public`) so that a caller-supplied image URL cannot be
+used to reach loopback, private-network or cloud-metadata services.
 """
 
 import io
+import ipaddress
 import logging
+import socket
 from typing import Tuple
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import requests
+
+from config import get_config
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +38,10 @@ MAX_IMAGE_SIZE = 10 * 1024 * 1024
 # Request timeout in seconds
 REQUEST_TIMEOUT = 30
 
+# Maximum number of HTTP redirects to follow. Every hop is re-validated, so a
+# public URL cannot bounce the request onto an internal address.
+MAX_REDIRECTS = 5
+
 
 class ImageDownloadError(Exception):
     """Exception raised when image download fails."""
@@ -38,6 +50,15 @@ class ImageDownloadError(Exception):
 
 class ImageValidationError(Exception):
     """Exception raised when image validation fails."""
+    pass
+
+
+class SSRFProtectionError(ImageValidationError):
+    """Exception raised when a URL resolves to a non-public address.
+
+    Subclasses :class:`ImageValidationError` so callers that already handle
+    validation failures treat a blocked URL the same way.
+    """
     pass
 
 
@@ -57,6 +78,92 @@ def validate_url(url: str) -> bool:
         return False
 
 
+def _addr_is_public(ip) -> bool:
+    """Return True only for globally routable unicast addresses.
+
+    ``is_global`` already excludes loopback, RFC 1918, link-local (including
+    the 169.254.169.254 cloud-metadata address), CGNAT, documentation and
+    reserved ranges for both IPv4 and IPv6; multicast is rejected separately
+    because ``is_global`` does not cover it.
+    """
+    # Collapse IPv4-mapped IPv6 (::ffff:127.0.0.1) to the IPv4 address it targets.
+    ip = getattr(ip, 'ipv4_mapped', None) or ip
+    return ip.is_global and not (
+        ip.is_private or ip.is_loopback or ip.is_link_local
+        or ip.is_reserved or ip.is_multicast
+    )
+
+
+def assert_url_is_public(url: str) -> None:
+    """Raise unless every address the URL's host resolves to is public.
+
+    Resolution goes through ``getaddrinfo`` for *all* hosts, including bare IP
+    literals, so that alternative encodings (``2130706433``, ``0177.0.0.1``)
+    are normalised the same way the HTTP client will normalise them.
+
+    Known limitation: the hostname is resolved again when the connection is
+    made, so a DNS entry with a very short TTL can answer differently for the
+    two lookups (DNS rebinding). Closing that requires pinning the validated
+    address into the connection; it is not attempted here.
+
+    Args:
+        url: URL to check.
+
+    Raises:
+        SSRFProtectionError: If the host is missing, cannot be resolved, or
+            resolves to a non-public address.
+    """
+    if get_config().allow_private_image_addresses:
+        return
+
+    hostname = urlparse(url).hostname
+    if not hostname:
+        raise SSRFProtectionError(f"URL has no hostname: {url}")
+
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise SSRFProtectionError(f"Cannot resolve host '{hostname}': {e}")
+
+    for info in addr_infos:
+        address = ipaddress.ip_address(info[4][0])
+        if not _addr_is_public(address):
+            raise SSRFProtectionError(
+                f"Host '{hostname}' resolves to non-public address {address}"
+            )
+
+
+def _get_following_redirects(url: str) -> requests.Response:
+    """GET *url*, validating the initial URL and every redirect hop.
+
+    Redirects are followed manually because ``requests`` would otherwise
+    follow them without giving us a chance to check where they lead.
+    """
+    assert_url_is_public(url)
+
+    for _ in range(MAX_REDIRECTS + 1):
+        response = requests.get(
+            url,
+            timeout=REQUEST_TIMEOUT,
+            stream=True,
+            allow_redirects=False,
+            headers={
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) PowerPoint-MCP/1.0'
+            }
+        )
+        if not response.is_redirect:
+            response.raise_for_status()
+            return response
+
+        location = response.headers.get('Location')
+        if not location:
+            raise ImageDownloadError(f"Redirect without Location header from {url}")
+        url = urljoin(url, location)
+        assert_url_is_public(url)
+
+    raise ImageDownloadError(f"Too many redirects (>{MAX_REDIRECTS}) downloading image")
+
+
 def download_image(url: str) -> Tuple[io.BytesIO, str]:
     """Download an image from a URL and return it as a BytesIO object.
 
@@ -69,6 +176,8 @@ def download_image(url: str) -> Tuple[io.BytesIO, str]:
     Raises:
         ImageDownloadError: If download fails.
         ImageValidationError: If image validation fails.
+        SSRFProtectionError: If the URL, or any redirect it follows, resolves
+            to a non-public address.
     """
     if not validate_url(url):
         raise ImageValidationError(f"Invalid URL format: {url}")
@@ -76,15 +185,7 @@ def download_image(url: str) -> Tuple[io.BytesIO, str]:
     logger.info(f"Downloading image from: {url}")
 
     try:
-        response = requests.get(
-            url,
-            timeout=REQUEST_TIMEOUT,
-            stream=True,
-            headers={
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) PowerPoint-MCP/1.0'
-            }
-        )
-        response.raise_for_status()
+        response = _get_following_redirects(url)
 
     except requests.exceptions.Timeout:
         raise ImageDownloadError(f"Timeout downloading image from {url}")

--- a/pptx_tools/image_utils.py
+++ b/pptx_tools/image_utils.py
@@ -140,10 +140,16 @@ def _get_following_redirects(url: str) -> requests.Response:
     Redirects are followed manually because ``requests`` would otherwise
     follow them without giving us a chance to check where they lead.
 
-    ``REQUEST_TIMEOUT`` budgets the whole chain rather than each hop, so a
-    server cannot hold a worker thread for a multiple of it by chaining slow
-    redirects. Tool handlers run on a small bounded thread pool (see
-    RUN_BLOCKING_MAX_WORKERS), so that multiple matters.
+    ``REQUEST_TIMEOUT`` is shared across the whole chain rather than granted
+    afresh per hop, so chaining redirects no longer multiplies how long one
+    call can run. Tool handlers share a small bounded thread pool (see
+    RUN_BLOCKING_MAX_WORKERS), so that multiple mattered.
+
+    This is not a wall-clock guarantee: ``requests`` applies a timeout to each
+    socket operation, not to the transfer as a whole, so a server that dribbles
+    bytes just fast enough to keep resetting the read timeout can still hold a
+    hop, and the body read in :func:`download_image`, well past the budget.
+    Bounding that needs a deadline enforced across the body read too.
     """
     assert_url_is_public(url)
     deadline = time.monotonic() + REQUEST_TIMEOUT

--- a/tests/test_image_ssrf.py
+++ b/tests/test_image_ssrf.py
@@ -17,7 +17,7 @@ network access is involved).
 import socket
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 # Add project root to path for imports
 project_root = Path(__file__).parent.parent
@@ -25,8 +25,12 @@ sys.path.insert(0, str(project_root))
 
 import pytest
 
+import requests
+
 from pptx_tools.image_utils import (
+    REQUEST_TIMEOUT,
     SSRFProtectionError,
+    _get_following_redirects,
     assert_url_is_public,
     download_image,
 )
@@ -119,3 +123,52 @@ def test_redirect_to_private_address_is_blocked():
 def test_escape_hatch_allows_private_addresses(_protection_enabled):
     _protection_enabled.return_value.allow_private_image_addresses = True
     assert_url_is_public("http://127.0.0.1/image.png")  # does not raise
+
+
+def _redirect_to(location):
+    return MagicMock(is_redirect=True, headers={"Location": location})
+
+
+def test_intermediate_redirect_responses_are_closed():
+    """A 3xx body is never read, so its response is released explicitly."""
+    redirect = _redirect_to("https://example.com/final.png")
+    final = MagicMock(is_redirect=False, headers={"Content-Type": "image/png"})
+    final.iter_content.return_value = [b"image-bytes"]
+
+    with patch.object(socket, "getaddrinfo", _resolver({"example.com": ["93.184.216.34"]})):
+        with patch("pptx_tools.image_utils.requests.get", side_effect=[redirect, final]):
+            download_image("https://example.com/image.png")
+
+    redirect.close.assert_called_once()
+
+
+def test_redirect_chain_shares_one_timeout_budget():
+    """The whole chain is bounded by REQUEST_TIMEOUT, not each hop separately."""
+    redirect = _redirect_to("https://example.com/next.png")
+    # monotonic(): deadline base, then one reading per loop iteration.
+    clock = iter([0.0, 0.0, REQUEST_TIMEOUT + 1])
+
+    with patch.object(socket, "getaddrinfo", _resolver({"example.com": ["93.184.216.34"]})):
+        with patch("pptx_tools.image_utils.time.monotonic", lambda: next(clock)):
+            with patch("pptx_tools.image_utils.requests.get", return_value=redirect):
+                with pytest.raises(requests.exceptions.Timeout):
+                    _get_following_redirects("https://example.com/image.png")
+
+
+def test_each_hop_gets_only_the_remaining_budget():
+    """A hop's timeout shrinks as the shared budget is consumed."""
+    redirect = _redirect_to("https://example.com/next.png")
+    final = MagicMock(is_redirect=False, headers={})
+    clock = iter([0.0, 0.0, 10.0])
+    timeouts = []
+
+    def _get(url, **kwargs):
+        timeouts.append(kwargs["timeout"])
+        return redirect if len(timeouts) == 1 else final
+
+    with patch.object(socket, "getaddrinfo", _resolver({"example.com": ["93.184.216.34"]})):
+        with patch("pptx_tools.image_utils.time.monotonic", lambda: next(clock)):
+            with patch("pptx_tools.image_utils.requests.get", _get):
+                _get_following_redirects("https://example.com/image.png")
+
+    assert timeouts == [REQUEST_TIMEOUT, REQUEST_TIMEOUT - 10.0]

--- a/tests/test_image_ssrf.py
+++ b/tests/test_image_ssrf.py
@@ -1,0 +1,121 @@
+"""Tests for SSRF protection on caller-supplied image URLs.
+
+Covers:
+- Non-public literals (loopback, RFC 1918, link-local/cloud metadata) blocked
+- Alternative IP encodings (decimal, octal, IPv4-mapped IPv6) blocked
+- Public addresses allowed
+- Unresolvable hosts rejected rather than passed through
+- Redirects to a non-public address blocked
+- SSRF_ALLOW_PRIVATE_ADDRESSES escape hatch
+
+Hostname resolution is stubbed where a test would otherwise need DNS; the
+alternative-encoding cases deliberately use the real resolver because
+normalising them is the behaviour under test (libc parses them locally, so no
+network access is involved).
+"""
+
+import socket
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Add project root to path for imports
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import pytest
+
+from pptx_tools.image_utils import (
+    SSRFProtectionError,
+    assert_url_is_public,
+    download_image,
+)
+
+
+@pytest.fixture(autouse=True)
+def _protection_enabled():
+    """Run every test with protection on unless it opts out."""
+    with patch("pptx_tools.image_utils.get_config") as get_config:
+        get_config.return_value.allow_private_image_addresses = False
+        yield get_config
+
+
+def _resolver(hosts):
+    """Stub getaddrinfo from a {hostname: [address, ...]} mapping.
+
+    Hosts not in the mapping resolve to themselves, so an IP literal in a
+    redirect target still behaves like the real resolver.
+    """
+    def _getaddrinfo(host, *a, **kw):
+        return [(None, None, None, "", (addr, 0)) for addr in hosts.get(host, [host])]
+    return _getaddrinfo
+
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1/image.png",                      # loopback
+    "http://[::1]/image.png",                          # IPv6 loopback
+    "http://10.0.0.1/image.png",                       # RFC 1918
+    "http://192.168.1.1/image.png",                    # RFC 1918
+    "http://172.16.0.1/image.png",                     # RFC 1918
+    "http://169.254.169.254/latest/meta-data/",        # cloud metadata
+    "http://100.64.0.1/image.png",                     # CGNAT
+    "http://0.0.0.0/image.png",                        # unspecified
+    "http://user:pass@127.0.0.1/image.png",            # credentials do not bypass
+    "http://127.0.0.1:8080/image.png",                 # port does not bypass
+])
+def test_non_public_addresses_are_blocked(url):
+    with pytest.raises(SSRFProtectionError):
+        assert_url_is_public(url)
+
+
+@pytest.mark.parametrize("url", [
+    "http://2130706433/image.png",         # 127.0.0.1 in decimal
+    "http://0177.0.0.1/image.png",         # 127.0.0.1 with an octal first octet
+    "http://[::ffff:127.0.0.1]/image.png",  # IPv4-mapped IPv6
+])
+def test_alternative_encodings_of_loopback_are_blocked(url):
+    """These forms bypass a naive ipaddress.ip_address() blocklist check."""
+    with pytest.raises(SSRFProtectionError):
+        assert_url_is_public(url)
+
+
+def test_public_address_is_allowed():
+    with patch.object(socket, "getaddrinfo", _resolver({"example.com": ["93.184.216.34"]})):
+        assert_url_is_public("https://example.com/image.png")  # does not raise
+
+
+def test_all_resolved_addresses_must_be_public():
+    """A host with one public and one private record is rejected."""
+    resolver = _resolver({"split-horizon.example": ["93.184.216.34", "10.0.0.5"]})
+    with patch.object(socket, "getaddrinfo", resolver):
+        with pytest.raises(SSRFProtectionError, match="10.0.0.5"):
+            assert_url_is_public("https://split-horizon.example/image.png")
+
+
+def test_unresolvable_host_is_rejected():
+    def _fail(*a, **kw):
+        raise socket.gaierror("Name or service not known")
+
+    with patch.object(socket, "getaddrinfo", _fail):
+        with pytest.raises(SSRFProtectionError, match="Cannot resolve"):
+            assert_url_is_public("https://no-such-host.example/image.png")
+
+
+def test_url_without_hostname_is_rejected():
+    with pytest.raises(SSRFProtectionError, match="no hostname"):
+        assert_url_is_public("file:///etc/passwd")
+
+
+def test_redirect_to_private_address_is_blocked():
+    """A public URL must not be able to bounce the request onto loopback."""
+    with patch.object(socket, "getaddrinfo", _resolver({"example.com": ["93.184.216.34"]})):
+        with patch("pptx_tools.image_utils.requests.get") as get:
+            get.return_value.is_redirect = True
+            get.return_value.headers = {"Location": "http://127.0.0.1/secret.png"}
+            with pytest.raises(SSRFProtectionError):
+                download_image("https://example.com/image.png")
+
+
+def test_escape_hatch_allows_private_addresses(_protection_enabled):
+    _protection_enabled.return_value.allow_private_image_addresses = True
+    assert_url_is_public("http://127.0.0.1/image.png")  # does not raise


### PR DESCRIPTION
Alternative to #92, built from scratch on `master`. Same underlying issue, minimal implementation.

## The issue, re-scoped

`download_image()` takes a URL straight from caller-supplied tool arguments (`image_url` in a slide spec, markdown `[]()` in the docx path) and fetched it with no address check, following redirects blindly. That allows probing loopback and private-network services from the server.

Scoping it honestly, this is **Medium, not Critical**:

- Callers are authenticated behind `ApiKeyAuthMiddleware` — not an anonymous endpoint. (Severity rises if `API_KEY` is left unset.)
- The cloud-credential-theft angle doesn't hold in practice: GCP metadata requires `Metadata-Flavor: Google`, Azure requires `Metadata: true`, and AWS IMDSv2 requires a PUT for a token. A plain GET reaches none of them, and only legacy EC2 IMDSv1 is exposed — where the existing content-type allowlist rejects its `text/plain` response before the body reaches the document.
- What remains is genuine: blind SSRF (internal port/host probing via timing and error messages), plus a read primitive against internal services returning an image content-type or no `Content-Type` at all.

The filename-sanitization concern raised in #92 is **not a vulnerability** and is not addressed here. The existing `re.sub(r'[^\w\s\-.]', '', name)` already strips path separators and control characters — `'../../etc/passwd'` becomes `'....etcpasswd'`. No traversal was possible.

## The fix

`+142 −10` across three files, no new config file.

**Address check** — `assert_url_is_public()` resolves the host and requires every returned address to be publicly routable, using `ipaddress`'s own classifiers. `is_global` covers loopback, RFC 1918, link-local (including `169.254.169.254`), CGNAT, documentation and reserved ranges in both families; multicast is rejected separately since `is_global` doesn't cover it.

Three details make it hold:

- `getaddrinfo` runs for **every** host, including bare IP literals. That normalizes `2130706433` and `0177.0.0.1` to `127.0.0.1` using the same resolution the HTTP client will perform, so validation and connection can't disagree on the parse.
- `.ipv4_mapped` collapses `[::ffff:127.0.0.1]` before the check.
- **All** resolved addresses must pass, not any — the permissive variant is a bypass.

**Redirects** are now followed manually (`allow_redirects=False`) so every hop is re-validated. Previously a public URL could redirect onto an internal one.

**`SSRFProtectionError` subclasses `ImageValidationError`**, so both existing call sites handle a blocked URL through the paths they already have — no caller changes needed.

## Verified

Against a live loopback HTTP server, all five previously-working paths are blocked: direct `127.0.0.1`, decimal, octal, IPv4-mapped IPv6, and redirect-to-loopback.

19 new tests in `tests/test_image_ssrf.py`, all asserting. Full suite: **904 passed, same 52 pre-existing failures as clean `master`** (sandbox dependency gaps) — no regressions. `ruff` clean.

## Known limitation, stated rather than papered over

The host is resolved again when the connection is made, so **DNS rebinding is not closed**. Doing so requires pinning the validated address into the connection while preserving `Host:` and TLS SNI — more transport plumbing than this whole PR, for an attack needing attacker-controlled authoritative DNS. Given callers are already authenticated and the payoff is blind SSRF, that trade is documented in the `assert_url_is_public` docstring instead of being implemented.

## What this will break

Any image served from a private address stops working: in EKS, pods on 10.x/172.16.x; in compose, service names like `minio` or `api`. Split-horizon DNS is the subtle case — a public-looking hostname mapped internally to a private mirror is rejected, though the error names the resolved address so it's diagnosable from logs. Nothing in the codebase does this today, but it's the foreseeable breakage and the reason the escape hatch exists.

Also: one extra DNS lookup per image (resolver-cached, negligible against a 30s timeout), and unresolvable hosts now fail earlier with a different exception — user-visible behaviour is unchanged, since both call sites already catch it.

## Config

One variable, routed through `config.py`, which already declares itself the single source of truth for env access:

```
SSRF_ALLOW_PRIVATE_ADDRESSES=    # default false
```

Set it only where images are legitimately served from inside your network. Documented in `.env.example` in the existing house style.
