### PR TITLE
feat(upload): add PERSONAL_FILES strategy to store documents in librechat-personal-files-mcp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,7 +79,7 @@ SSRF_ALLOW_PRIVATE_ADDRESSES=
 STATELESS_HTTP=
 
 # --- Storage / Upload strategy ---
-# One of: LOCAL, S3, GCS, AZURE, MINIO, LIBRECHAT
+# One of: LOCAL, S3, GCS, AZURE, MINIO, LIBRECHAT, PERSONAL_FILES
 UPLOAD_STRATEGY=LOCAL
 # How long generated download links remain valid (in seconds) for S3/GCS/AZURE
 SIGNED_URL_EXPIRES_IN=3600
@@ -147,3 +147,22 @@ AZURE_BLOB_ENDPOINT=
 #
 LIBRECHAT_SERVICE_URL=
 LIBRECHAT_SERVICE_TOKEN=
+
+# --- Personal-Files Integration (required when UPLOAD_STRATEGY=PERSONAL_FILES) ---
+#
+# When UPLOAD_STRATEGY=PERSONAL_FILES, documents are pushed (multipart) to the
+# librechat-personal-files-mcp POST /binary endpoint and stored in the user's
+# private storage. The agent receives a relative path + metadata, not a file
+# artifact (publish later with the personal-files publish_file tool).
+#
+# PERSONAL_FILES_URL: Base URL of the personal-files MCP server.
+#   Typically: http://librechat-personal-files:8080 (inside Docker network)
+#
+# PERSONAL_FILES_SERVICE_TOKEN: Must match SERVICE_TOKEN on the personal-files
+#   server. Generate with: openssl rand -hex 32
+#
+# PERSONAL_FILES_PATH_PREFIX: subfolder inside the user root (default "office").
+#
+PERSONAL_FILES_URL=
+PERSONAL_FILES_SERVICE_TOKEN=
+PERSONAL_FILES_PATH_PREFIX=office

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ config/
 
 # Agent Zero project files (local only)
 .a0proj/
+
+# Internal working documents (not part of the public repo)
+documentacao-mcp-ms-office-documents.md

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,3 @@ config/
 
 # Agent Zero project files (local only)
 .a0proj/
-
-# Internal working documents (not part of the public repo)
-documentacao-mcp-ms-office-documents.md

--- a/Readme.md
+++ b/Readme.md
@@ -102,7 +102,7 @@ The server is configured through environment variables in your `.env` file.
 |----------|-------------|---------|
 | `DEBUG` | Enable debug logging (`1`, `true`, `yes`) | _(off)_ |
 | `API_KEY` | Protect the server with an API key (see Authentication below) | _(disabled)_ |
-| `UPLOAD_STRATEGY` | Where to save files: `LOCAL`, `S3`, `GCS`, `AZURE`, `MINIO` | `LOCAL` |
+| `UPLOAD_STRATEGY` | Where to save files: `LOCAL`, `S3`, `GCS`, `AZURE`, `MINIO`, `LIBRECHAT`, `PERSONAL_FILES` | `LOCAL` |
 | `SIGNED_URL_EXPIRES_IN` | How long cloud download links stay valid (seconds) | `3600` |
 | `RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED` | Offload blocking tool work to a thread pool, keeping the event loop free for health probes & concurrent requests | `true` |
 | `RUN_BLOCKING_MAX_WORKERS` | Maximum concurrent worker threads for blocking tool calls | `4` |
@@ -239,6 +239,35 @@ mcpServers:
 ```
 
 The `X-User-Id` and `X-User-Email` headers are automatically populated by LibreChat and used to associate uploaded files with the correct user.
+
+</details>
+
+<details>
+<summary><strong>📁 Personal-Files Integration</strong></summary>
+
+This fork adds a `PERSONAL_FILES` upload strategy that stores generated
+documents in a user's private storage via the
+[`librechat-personal-files-mcp`](https://github.com/martinriesel/librechat-personal-files-mcp)
+server. Set `UPLOAD_STRATEGY=PERSONAL_FILES`; every generated file is pushed
+(multipart) to the personal-files `POST /binary` endpoint and returned to the
+agent as a relative path + metadata (`path`, `mime_type`, `size_bytes`,
+`sha256`) — **not** auto-published. The agent can later call the
+personal-files tools (`publish_file`, `read_binary_file`, `list_files`, …).
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `PERSONAL_FILES_URL` | Base URL of the personal-files MCP server (e.g. `http://librechat-personal-files:8080`) | ✅ |
+| `PERSONAL_FILES_SERVICE_TOKEN` | Service token; must match `SERVICE_TOKEN` on the personal-files server | ✅ |
+| `PERSONAL_FILES_PATH_PREFIX` | Subfolder inside the user root (default `office`) | |
+
+**Filename uniqueness:** the `add_unique_prefix` parameter defaults to `False`
+for `PERSONAL_FILES` (clean filenames such as `office/Report.docx`), matching
+the `LIBRECHAT` behavior.
+
+The personal-files server needs `SERVICE_TOKEN` set and a writable
+`/data/private` volume. Generated Office files land in
+`/data/private/<userId>/office/` and can be published later with
+`publish_file` (public links work for binary files).
 
 </details>
 

--- a/config.py
+++ b/config.py
@@ -246,6 +246,43 @@ class LibreChatSettings(BaseModel):
         return self
 
 
+class PersonalFilesSettings(BaseModel):
+    """Configuration for the personal-files MCP storage backend.
+
+    When UPLOAD_STRATEGY is set to PERSONAL_FILES, generated documents are
+    pushed (multipart) to the librechat-personal-files-mcp ``POST /binary``
+    endpoint, which stores them in the user's private storage and returns
+    the relative path.
+
+    Required environment variables:
+    - PERSONAL_FILES_URL: Base URL of the personal-files MCP server
+      (e.g. http://librechat-personal-files:8080)
+    - PERSONAL_FILES_SERVICE_TOKEN: Service token that must match
+      SERVICE_TOKEN in the personal-files server.
+    Optional:
+    - PERSONAL_FILES_PATH_PREFIX: subdirectory inside the user root where
+      documents are stored (default "office").
+    """
+    url: str = Field(description="Personal-files MCP server base URL")
+    service_token: str = Field(description="Service token for the /binary endpoint")
+    path_prefix: str = Field(default="office", description="Subfolder inside the user root")
+
+    @model_validator(mode="after")
+    def _non_empty(self) -> "PersonalFilesSettings":
+        missing = [
+            name for name, val in (
+                ("PERSONAL_FILES_URL", self.url),
+                ("PERSONAL_FILES_SERVICE_TOKEN", self.service_token),
+            ) if not str(val).strip()
+        ]
+        if missing:
+            raise ValueError(f"Missing required PersonalFiles settings: {', '.join(missing)}")
+        self.url = self.url.strip().rstrip("/")
+        self.service_token = self.service_token.strip()
+        self.path_prefix = self.path_prefix.strip().strip("/") or "office"
+        return self
+
+
 class StorageStrategy(str, Enum):
     """Supported upload backends for produced documents."""
     LOCAL = "LOCAL"
@@ -254,6 +291,7 @@ class StorageStrategy(str, Enum):
     AZURE = "AZURE"
     MINIO = "MINIO"
     LIBRECHAT = "LIBRECHAT"
+    PERSONAL_FILES = "PERSONAL_FILES"
 
 
 class StorageSettings(BaseModel):
@@ -271,6 +309,7 @@ class StorageSettings(BaseModel):
     azure: Optional[AzureSettings] = None
     minio: Optional[MinioSettings] = None
     librechat: Optional[LibreChatSettings] = None
+    personal_files: Optional[PersonalFilesSettings] = None
 
     @model_validator(mode="after")
     def validate_strategy_requirements(self) -> "StorageSettings":
@@ -290,6 +329,9 @@ class StorageSettings(BaseModel):
         elif self.strategy == StorageStrategy.LIBRECHAT:
             if not self.librechat:
                 raise ValueError("LibreChat settings are required for LIBRECHAT strategy")
+        elif self.strategy == StorageStrategy.PERSONAL_FILES:
+            if not self.personal_files:
+                raise ValueError("PersonalFiles settings are required for PERSONAL_FILES strategy")
         return self
 
 
@@ -434,6 +476,7 @@ class Config(BaseModel):
         azure_settings = None
         minio_settings = None
         librechat_settings = None
+        personal_files_settings = None
 
         if strategy == StorageStrategy.S3.value:
             s3_settings = S3Settings(
@@ -469,6 +512,12 @@ class Config(BaseModel):
                 service_url=os.environ.get("LIBRECHAT_SERVICE_URL", ""),
                 service_token=os.environ.get("LIBRECHAT_SERVICE_TOKEN", ""),
             )
+        elif strategy == StorageStrategy.PERSONAL_FILES.value:
+            personal_files_settings = PersonalFilesSettings(
+                url=os.environ.get("PERSONAL_FILES_URL", ""),
+                service_token=os.environ.get("PERSONAL_FILES_SERVICE_TOKEN", ""),
+                path_prefix=os.environ.get("PERSONAL_FILES_PATH_PREFIX", "office"),
+            )
 
         storage_settings = StorageSettings(
             strategy=StorageStrategy(strategy),
@@ -478,6 +527,7 @@ class Config(BaseModel):
             azure=azure_settings,
             minio=minio_settings,
             librechat=librechat_settings,
+            personal_files=personal_files_settings,
         )
 
         # API key authentication (optional – empty/missing means no auth)

--- a/librechat_integration.py
+++ b/librechat_integration.py
@@ -10,14 +10,21 @@ from typing import Optional, Union
 
 from async_runner import run_blocking
 from upload_tools import upload_file_async, is_librechat_strategy
+from config import get_config, StorageStrategy
 
-# NOTE: upload_tools.backends.librechat is imported lazily inside the LIBRECHAT
-# branch below, not here. It pulls in httpx, and this module is imported by
-# main.py on every startup — an eager import would make an optional backend's
-# dependency mandatory for all strategies. The other backends follow the same
-# rule (see the boto3 comment in upload_tools/backends/s3.py).
+# NOTE: upload_tools.backends.librechat and upload_tools.backends.personal_files
+# are imported lazily inside the strategy branches below, not here. They pull
+# in httpx, and this module is imported by main.py on every startup — an eager
+# import would make an optional backend's dependency mandatory for all
+# strategies. The other backends follow the same rule (see the boto3 comment in
+# upload_tools/backends/s3.py).
 
 logger = logging.getLogger(__name__)
+
+
+def _is_personal_files_strategy() -> bool:
+    cfg = get_config()
+    return cfg.storage.strategy == StorageStrategy.PERSONAL_FILES
 
 
 def extract_user_context_from_request() -> dict:
@@ -92,7 +99,8 @@ async def upload_and_format_response(
             (True for traditional backends, False for LIBRECHAT).
 
     Returns:
-        str (URL) for traditional backends, or dict (file artifact) for LIBRECHAT
+        str (URL) for traditional backends, dict (file artifact) for LIBRECHAT,
+        or str (path + metadata) for PERSONAL_FILES.
     """
     if is_librechat_strategy():
         from upload_tools.backends.librechat import format_file_artifact
@@ -115,6 +123,26 @@ async def upload_and_format_response(
 
         # Format as MCP file artifact
         return format_file_artifact(file_info, success_message)
+    elif _is_personal_files_strategy():
+        from upload_tools.backends.personal_files import format_personal_files_result
+
+        # Validate user context for PERSONAL_FILES
+        if not user_context.get("user_id"):
+            raise ValueError(
+                "Personal-files upload requires X-User-Id header. "
+                "Ensure LibreChat is configured to send user headers to MCP server."
+            )
+
+        file_info = await upload_file_async(
+            file_buffer,
+            suffix,
+            filename=filename,
+            user_context=user_context,
+            add_unique_prefix=add_unique_prefix,
+        )
+
+        # Format as path + metadata string (the agent can publish_file later).
+        return format_personal_files_result(file_info, success_message)
     else:
         # Traditional upload - returns URL string.
         #

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -66,11 +66,18 @@ class TestStorageStrategy:
         assert hasattr(StorageStrategy, "LIBRECHAT")
         assert StorageStrategy.LIBRECHAT.value == "LIBRECHAT"
 
+    def test_personal_files_in_storage_strategy(self):
+        """Test PERSONAL_FILES is a valid storage strategy."""
+        from config import StorageStrategy
+
+        assert hasattr(StorageStrategy, "PERSONAL_FILES")
+        assert StorageStrategy.PERSONAL_FILES.value == "PERSONAL_FILES"
+
     def test_all_strategies_present(self):
         """Test all expected strategies are present."""
         from config import StorageStrategy
 
-        expected = {"LOCAL", "S3", "GCS", "AZURE", "MINIO", "LIBRECHAT"}
+        expected = {"LOCAL", "S3", "GCS", "AZURE", "MINIO", "LIBRECHAT", "PERSONAL_FILES"}
         actual = {s.value for s in StorageStrategy}
         assert expected == actual
 

--- a/tests/test_personal_files_backend.py
+++ b/tests/test_personal_files_backend.py
@@ -1,0 +1,178 @@
+"""Tests for the personal-files MCP storage backend.
+
+Covers PersonalFilesSettings validation, upload_to_personal_files (with a
+mocked httpx client) and format_personal_files_result.
+"""
+
+import io
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+
+class TestPersonalFilesSettings:
+    """Test PersonalFilesSettings configuration model."""
+
+    def test_settings_valid(self):
+        from config import PersonalFilesSettings
+
+        settings = PersonalFilesSettings(
+            url="http://librechat-personal-files:8080",
+            service_token="s" * 16,
+        )
+        assert settings.url == "http://librechat-personal-files:8080"
+        assert settings.service_token == "s" * 16
+        assert settings.path_prefix == "office"
+
+    def test_settings_strips_trailing_slash_and_prefix(self):
+        from config import PersonalFilesSettings
+
+        settings = PersonalFilesSettings(
+            url="http://host:8080/",
+            service_token="s" * 16,
+            path_prefix="/docs/",
+        )
+        assert settings.url == "http://host:8080"
+        assert settings.path_prefix == "docs"
+
+    def test_settings_missing_url_raises(self):
+        from config import PersonalFilesSettings
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PersonalFilesSettings(url="", service_token="s" * 16)
+
+    def test_settings_missing_token_raises(self):
+        from config import PersonalFilesSettings
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PersonalFilesSettings(url="http://host:8080", service_token="")
+
+
+class TestUploadToPersonalFiles:
+    """Test upload_to_personal_files function."""
+
+    def _settings(self):
+        from config import PersonalFilesSettings
+
+        return PersonalFilesSettings(
+            url="http://librechat-personal-files:8080",
+            service_token="s" * 16,
+            path_prefix="office",
+        )
+
+    @pytest.mark.asyncio
+    async def test_upload_missing_user_id_raises(self):
+        from upload_tools.backends.personal_files import upload_to_personal_files
+
+        config = self._settings()
+        file_buffer = io.BytesIO(b"test content")
+        user_context = {"user_id": None}
+
+        with pytest.raises(ValueError, match="user_id"):
+            await upload_to_personal_files(file_buffer, "document.docx", user_context, config)
+
+    @pytest.mark.asyncio
+    async def test_upload_success(self):
+        from upload_tools.backends.personal_files import upload_to_personal_files
+
+        config = self._settings()
+        file_buffer = io.BytesIO(b"test content")
+        user_context = {
+            "user_id": "user-123",
+            "user_email": "test@example.com",
+            "conversation_id": "conv-456",
+        }
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "path": "office/document.docx",
+            "filename": "document.docx",
+            "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "size_bytes": 12,
+            "sha256": "abc123",
+        }
+
+        with patch("upload_tools.backends.personal_files.httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.post = AsyncMock(return_value=mock_response)
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            result = await upload_to_personal_files(
+                file_buffer, "document.docx", user_context, config
+            )
+
+            assert result["path"] == "office/document.docx"
+            assert result["filename"] == "document.docx"
+            assert result["size_bytes"] == 12
+            assert result["sha256"] == "abc123"
+
+            # Verify request headers included service token + user id
+            _, kwargs = mock_instance.post.call_args
+            headers = kwargs["headers"]
+            assert headers["X-Service-Token"] == "s" * 16
+            assert headers["X-User-Id"] == "user-123"
+            assert headers["X-User-Email"] == "test@example.com"
+            assert kwargs["data"]["path"] == "office/document.docx"
+            # URL hits the /binary endpoint
+            assert mock_instance.post.call_args.args[0] == "http://librechat-personal-files:8080/binary"
+
+    @pytest.mark.asyncio
+    async def test_upload_http_error(self):
+        from upload_tools.backends.personal_files import upload_to_personal_files
+
+        config = self._settings()
+        file_buffer = io.BytesIO(b"data")
+        user_context = {"user_id": "user-123"}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"error": "invalid_service_token"}
+        mock_response.text = '{"error": "invalid_service_token"}'
+        from httpx import HTTPStatusError
+
+        mock_response.raise_for_status.side_effect = HTTPStatusError(
+            "401", request=MagicMock(), response=mock_response
+        )
+
+        with patch("upload_tools.backends.personal_files.httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.post = AsyncMock(return_value=mock_response)
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            with pytest.raises(RuntimeError, match="invalid_service_token"):
+                await upload_to_personal_files(file_buffer, "document.docx", user_context, config)
+
+
+class TestFormatPersonalFilesResult:
+    """Test format_personal_files_result."""
+
+    def test_formats_path_and_metadata(self):
+        from upload_tools.backends.personal_files import format_personal_files_result
+
+        file_info = {
+            "path": "office/document.docx",
+            "filename": "document.docx",
+            "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "size_bytes": 12345,
+            "sha256": "abc",
+        }
+
+        result = format_personal_files_result(file_info, "Document saved.")
+        assert "Document saved." in result
+        assert "path: office/document.docx" in result
+        assert "size_bytes: 12345" in result
+        assert "mime_type: application/vnd.openxmlformats" in result
+        assert "sha256: abc" in result
+
+    def test_formats_minimal_info(self):
+        from upload_tools.backends.personal_files import format_personal_files_result
+
+        result = format_personal_files_result({"path": "office/x.docx", "size_bytes": 3})
+        assert "saved_to_personal_files: true" in result
+        assert "path: office/x.docx" in result

--- a/upload_tools/backends/personal_files.py
+++ b/upload_tools/backends/personal_files.py
@@ -1,0 +1,160 @@
+"""personal-files MCP storage backend.
+
+Pushes generated documents (multipart) to the librechat-personal-files-mcp
+``POST /binary`` endpoint, which stores the file in the requesting user's
+private storage. Returns the relative path + metadata so the agent can point
+back at the file (e.g. via the personal-files ``publish_file`` tool).
+"""
+
+import io
+import logging
+from typing import Optional
+
+import httpx
+
+from config import PersonalFilesSettings
+
+logger = logging.getLogger(__name__)
+
+
+async def upload_to_personal_files(
+    file_object: io.BytesIO,
+    filename: str,
+    user_context: dict,
+    config: PersonalFilesSettings,
+    timeout: float = 120.0,
+) -> dict:
+    """Upload a file to the personal-files server.
+
+    Args:
+        file_object: BytesIO object containing the file data.
+        filename: Name of the file (with extension).
+        user_context: Dict with user info from request headers:
+            - user_id: Required (from X-User-Id)
+            - user_email: Optional
+            - conversation_id: Optional
+        config: PersonalFilesSettings with url, service_token, path_prefix.
+        timeout: Request timeout in seconds (default 120).
+
+    Returns:
+        Dict with file metadata:
+        {
+            "path": "office/My_Report.docx",
+            "filename": "My_Report.docx",
+            "mime_type": "application/vnd.openxmlformats-...",
+            "size_bytes": 12345,
+            "sha256": "...",
+        }
+
+    Raises:
+        ValueError: If user_context is missing required user_id.
+        RuntimeError: If upload fails.
+    """
+    user_id = user_context.get("user_id")
+    if not user_id:
+        raise ValueError(
+            "Personal-files upload requires user_id in user_context. "
+            "Ensure X-User-Id header is passed from LibreChat."
+        )
+
+    # The server resolves the path itself; we just ask for prefix/filename.
+    relative_path = f"{config.path_prefix}/{filename}"
+
+    headers = {
+        "X-Service-Token": config.service_token,
+        "X-User-Id": user_id,
+    }
+    if user_context.get("user_email"):
+        headers["X-User-Email"] = user_context["user_email"]
+    if user_context.get("conversation_id"):
+        headers["X-Conversation-Id"] = user_context["conversation_id"]
+
+    file_object.seek(0)
+    file_size = len(file_object.getvalue())
+    files = {"file": (filename, file_object)}
+    data = {"path": relative_path}
+
+    logger.info(
+        "Uploading file to personal-files: %s (%d bytes) for user %s",
+        relative_path,
+        file_size,
+        user_id,
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                f"{config.url}/binary",
+                headers=headers,
+                files=files,
+                data=data,
+            )
+            response.raise_for_status()
+            result = response.json()
+    except httpx.TimeoutException as e:
+        logger.error("personal-files upload timeout: %s", e)
+        raise RuntimeError(
+            f"personal-files upload timed out after {timeout}s. "
+            "Check the personal-files MCP server is reachable."
+        ) from e
+    except httpx.HTTPStatusError as e:
+        detail = _extract_error(e.response)
+        logger.error("personal-files upload HTTP %s: %s", e.response.status_code, detail)
+        raise RuntimeError(f"personal-files upload failed: {detail}") from e
+    except httpx.RequestError as e:
+        logger.error("personal-files upload request error: %s", e)
+        raise RuntimeError(
+            f"personal-files upload failed: {e}. "
+            f"Check PERSONAL_FILES_URL ({config.url}) is accessible."
+        ) from e
+
+    if not isinstance(result, dict) or "path" not in result:
+        raise RuntimeError(
+            "personal-files upload succeeded but response is missing 'path'. "
+            f"Response: {result}"
+        )
+
+    logger.info(
+        "File uploaded successfully to personal-files: path=%s, size=%s",
+        result["path"],
+        result.get("size_bytes"),
+    )
+    return {
+        "path": result["path"],
+        "filename": result.get("filename", filename),
+        "mime_type": result.get("mime_type"),
+        "size_bytes": result.get("size_bytes", file_size),
+        "sha256": result.get("sha256"),
+    }
+
+
+def _extract_error(response: httpx.Response) -> str:
+    try:
+        body = response.json()
+        if isinstance(body, dict) and body.get("error"):
+            return f"HTTP {response.status_code}: {body['error']}"
+    except ValueError:
+        pass
+    return f"HTTP {response.status_code}: {response.text[:200]}"
+
+
+def format_personal_files_result(file_info: dict, text_message: Optional[str] = None) -> str:
+    """Format personal-files upload as a plain-text path + metadata response.
+
+    Returns a string the LLM can use to reference the stored file.
+    """
+    path = file_info.get("path", "unknown")
+    size = file_info.get("size_bytes", 0)
+    message = text_message or f"Document saved to personal files: {path}"
+
+    parts = [
+        "saved_to_personal_files: true",
+        f"path: {path}",
+        f"size_bytes: {size}",
+    ]
+    if file_info.get("mime_type"):
+        parts.append(f"mime_type: {file_info['mime_type']}")
+    if file_info.get("sha256"):
+        parts.append(f"sha256: {file_info['sha256']}")
+
+    return f"{message}\n" + "\n".join(parts)

--- a/upload_tools/main.py
+++ b/upload_tools/main.py
@@ -1,10 +1,13 @@
 """Unified file upload module supporting multiple storage backends.
 
 This module provides a centralized upload interface that dispatches to the
-configured storage backend (LOCAL, S3, GCS, AZURE, MINIO, or LIBRECHAT).
+configured storage backend (LOCAL, S3, GCS, AZURE, MINIO, LIBRECHAT, or
+PERSONAL_FILES).
 
 For LIBRECHAT strategy, uploads go to LibreChat's service endpoint and return
 file metadata for MCP file artifacts instead of URLs.
+For PERSONAL_FILES strategy, uploads go to the personal-files MCP server's
+``POST /binary`` endpoint and return path + metadata.
 """
 
 import logging
@@ -40,6 +43,8 @@ elif UPLOAD_STRATEGY == StorageStrategy.MINIO:
     logger.info("MinIO upload strategy set.")
 elif UPLOAD_STRATEGY == StorageStrategy.LIBRECHAT:
     logger.info("LibreChat upload strategy set.")
+elif UPLOAD_STRATEGY == StorageStrategy.PERSONAL_FILES:
+    logger.info("Personal-files upload strategy set.")
 
 
 def upload_file(
@@ -52,30 +57,35 @@ def upload_file(
     """Upload a file to configured backend and return appropriate response.
 
     For traditional backends (LOCAL, S3, GCS, AZURE, MINIO), returns a URL string.
-    For LIBRECHAT, this function raises an error - use upload_file_async instead.
+    For LIBRECHAT and PERSONAL_FILES, this function raises an error - use
+    upload_file_async instead.
 
     :param file_object: File-like object to upload
     :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
     :param filename: Optional human-readable filename (without extension). When provided,
         the uploaded object will use this name (sanitized).
-    :param user_context: Optional dict with user info for LIBRECHAT strategy:
-        - user_id: Required for LIBRECHAT
+    :param user_context: Optional dict with user info:
+        - user_id: Required for LIBRECHAT and PERSONAL_FILES
         - user_email: Optional
         - conversation_id: Optional
     :param add_unique_prefix: If True, adds 8-char UUID prefix to filename for uniqueness.
         If None (default), uses True for traditional backends (to prevent collisions) and
         False for LIBRECHAT (which handles uniqueness with its own UUID prefix).
     :return: Status message with download URL or save location (str for traditional backends)
-    :raises RuntimeError: If upload fails or LIBRECHAT strategy used without async
+    :raises RuntimeError: If upload fails or LIBRECHAT/PERSONAL_FILES strategy used without async
     """
     # Resolve default based on strategy: traditional backends default to True for collision safety,
-    # LIBRECHAT defaults to False since it handles uniqueness with its own UUID prefix.
+    # LIBRECHAT and PERSONAL_FILES default to False.
     if add_unique_prefix is None:
-        add_unique_prefix = UPLOAD_STRATEGY != StorageStrategy.LIBRECHAT
-    # LIBRECHAT requires async - direct callers to upload_file_async
-    if UPLOAD_STRATEGY == StorageStrategy.LIBRECHAT:
+        add_unique_prefix = UPLOAD_STRATEGY not in (
+            StorageStrategy.LIBRECHAT,
+            StorageStrategy.PERSONAL_FILES,
+        )
+    # LIBRECHAT / PERSONAL_FILES require async - direct callers to upload_file_async
+    if UPLOAD_STRATEGY in (StorageStrategy.LIBRECHAT, StorageStrategy.PERSONAL_FILES):
         raise RuntimeError(
-            "LIBRECHAT strategy requires async upload. Use upload_file_async() instead."
+            "LIBRECHAT/PERSONAL_FILES strategies require async upload. "
+            "Use upload_file_async() instead."
         )
 
     try:
@@ -130,21 +140,25 @@ async def upload_file_async(
     :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
     :param filename: Optional human-readable filename (without extension). When provided,
         the uploaded object will use this name (sanitized).
-    :param user_context: Dict with user info (required for LIBRECHAT):
-        - user_id: Required for LIBRECHAT
+    :param user_context: Dict with user info (required for LIBRECHAT and PERSONAL_FILES):
+        - user_id: Required
         - user_email: Optional
         - conversation_id: Optional
     :param add_unique_prefix: If True, adds 8-char UUID prefix to filename for uniqueness.
         If None (default), uses True for traditional backends (to prevent collisions) and
-        False for LIBRECHAT (which handles uniqueness with its own UUID prefix).
-    :return: URL string (traditional backends) or dict with file metadata (LIBRECHAT)
+        False for LIBRECHAT/PERSONAL_FILES.
+    :return: URL string (traditional backends), dict (LIBRECHAT artifact), or
+        path+metadata dict (PERSONAL_FILES)
     :raises RuntimeError: If upload fails
-    :raises ValueError: If LIBRECHAT used without user_context
+    :raises ValueError: If LIBRECHAT/PERSONAL_FILES used without user_context
     """
     # Resolve default based on strategy: traditional backends default to True for collision safety,
-    # LIBRECHAT defaults to False since it handles uniqueness with its own UUID prefix.
+    # LIBRECHAT and PERSONAL_FILES default to False.
     if add_unique_prefix is None:
-        add_unique_prefix = UPLOAD_STRATEGY != StorageStrategy.LIBRECHAT
+        add_unique_prefix = UPLOAD_STRATEGY not in (
+            StorageStrategy.LIBRECHAT,
+            StorageStrategy.PERSONAL_FILES,
+        )
 
     # Generate object name
     try:
@@ -179,6 +193,30 @@ async def upload_file_async(
         except Exception as e:
             logger.error("LibreChat upload failed: %s", e, exc_info=True)
             raise RuntimeError(f"Error uploading to LibreChat: {e}") from e
+
+    # Handle PERSONAL_FILES strategy (async)
+    if UPLOAD_STRATEGY == StorageStrategy.PERSONAL_FILES:
+        from .backends.personal_files import upload_to_personal_files
+
+        if not user_context:
+            raise ValueError(
+                "PERSONAL_FILES strategy requires user_context with user_id. "
+                "Ensure X-User-Id header is passed from LibreChat."
+            )
+
+        try:
+            result = await upload_to_personal_files(
+                file_object,
+                object_name,
+                user_context,
+                cfg.storage.personal_files,
+            )
+            return result
+        except (ValueError, RuntimeError):
+            raise
+        except Exception as e:
+            logger.error("personal-files upload failed: %s", e, exc_info=True)
+            raise RuntimeError(f"Error uploading to personal-files: {e}") from e
 
     # For non-LIBRECHAT strategies, use sync upload
     # (They don't need user_context and are not truly async)


### PR DESCRIPTION
## Summary

This is a suggestion for a new **`PERSONAL_FILES`** upload strategy, so generated documents can be stored in a user's private storage on a [`librechat-personal-files-mcp`](https://github.com/martinriesel/librechat-personal-files-mcp) server — following the exact same pattern already used by the `LIBRECHAT` strategy (#86).

These two MCP servers work really well together: this project generates the Office files, and `librechat-personal-files-mcp` solves the "what happens next" problem — it gives each user their own private folder, and can produce an opaque, token-based download link (`publish_file`) for the generated files, on top of the isolation advantages you'd expect.

## Motivation

With `LOCAL`/`S3`/`GCS`/`AZURE`/`MINIO`, generated files land in shared storage with no notion of "which user owns this document". LibreChat agents that want per-user, private, publishable storage have to wire that up themselves.

## What's new

A new upload strategy `UPLOAD_STRATEGY=PERSONAL_FILES` that pushes each generated document (multipart) to the personal-files `POST /binary` endpoint and returns a **relative path + metadata** to the agent (not a file artifact, and not auto-published).

| Variable | Description | Required |
|----------|-------------|----------|
| `PERSONAL_FILES_URL` | Base URL of the personal-files MCP server | ✅ |
| `PERSONAL_FILES_SERVICE_TOKEN` | Must match `SERVICE_TOKEN` on the personal-files server | ✅ |
| `PERSONAL_FILES_PATH_PREFIX` | Subfolder inside the user root (default `office`) | |

## Implementation notes

- Follows the existing backend conventions: centralized config in `config.py`, lazy backend import (like `librechat`), `httpx` multipart upload.
- Auth is service-to-service: `X-Service-Token` (compared with `secrets.compare_digest` on the receiver) plus `X-User-Id` for per-user routing.
- `add_unique_prefix` defaults to `False` for `PERSONAL_FILES` (clean filenames like `office/Report.docx`), matching `LIBRECHAT`.
- New tests in `tests/test_personal_files_backend.py` (settings validation, upload with mocked httpx, response formatting).

This is submitted as a suggestion — happy to adjust naming, scope, or docs to fit the project. If you'd prefer to keep it as a downstream fork, that's fine too.
