### PR TITLE
fix(pptx): Phase 0 — harden slide input handling and template slide removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Lint & Test
 
 on:
+  push:
+    branches: ["master"]
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -17,12 +20,18 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
+      # requirements-dev.txt pulls in requirements.txt plus ruff and
+      # pytest-asyncio. Installing only requirements.txt left both the lint and
+      # the test step without their tool, which went unnoticed while this
+      # workflow ran on manual dispatch only.
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-dev.txt
 
       - name: Run ruff linter
         run: ruff check .
 
+      # Tests marked `network` reach out to a public image host; they stay out
+      # of CI so a third-party outage can never fail an unrelated pull request.
       - name: Run tests
-        run: pytest --tb=short -q
+        run: pytest --tb=short -q -m "not network"
 

--- a/main.py
+++ b/main.py
@@ -299,15 +299,15 @@ async def create_powerpoint_presentation(
 - title: {slide_type: "title", slide_title: str, subtitle?: str}  (subtitle can contain author name, tagline, date, etc.)
 - section: {slide_type: "section", slide_title: str}
 - content: {slide_type: "content", slide_title: str, slide_text: [{text: str, indentation_level: int (1-3)}]}
-- table: {slide_type: "table", slide_title: str, table_data: [[str]] (first row = header; optional second row with :---|:---:|---: for left/center/right column alignment), header_color?: str (hex), alternate_rows?: bool}
+- table: {slide_type: "table", slide_title: str, table_data: [[str|number|null]] (first row = header; optional second row with :---|:---:|---: for left/center/right column alignment), header_color?: str (6-digit hex, with or without '#'), alternate_rows?: bool}
 - image: {slide_type: "image", slide_title?: str, image_url: str, image_caption?: str}
 - two_column: {slide_type: "two_column", slide_title: str, left_column: [{text: str, indentation_level: int}], right_column: [{text: str, indentation_level: int}], left_heading?: str, right_heading?: str}
-- chart: {slide_type: "chart", slide_title: str, chart_type: str (bar|bar_stacked|column|column_stacked|line|line_markers|pie|doughnut|area|area_stacked|scatter|radar), chart_data: {categories: [str], series: [{name: str, values: [number]}]}, has_legend?: bool, legend_position?: str}
+- chart: {slide_type: "chart", slide_title: str, chart_type: str (bar|bar_stacked|column|column_stacked|line|line_markers|pie|doughnut|area|area_stacked|radar), chart_data: {categories: [str], series: [{name: str, values: [number]}]}, has_legend?: bool, legend_position?: str}
 - quote: {slide_type: "quote", slide_title?: str, quote_text: str, quote_author?: str}
 
-All slides support optional 'speaker_notes': str field.
+All slides support optional 'speaker_notes': str field. An unrecognised slide_type is rejected with an error listing the valid types — it is never skipped silently.
 
-Inline markdown formatting is supported in text fields (slide_text, quote_text, left_column, right_column): **bold**, *italic*, ***bold italic***, ~~strikethrough~~, __underline__, `code`."""
+Inline markdown formatting is supported in text fields (slide_text, quote_text, left_column, right_column): **bold**, *italic*, ***bold italic***, ~~strikethrough~~, __underline__, `code`. A marker only formats when it hugs its text (**bold**, not ** bold **), so ordinary prose such as "5 * 3 * 2" is left alone. Escape a literal marker with a backslash (\\*), or wrap it in backticks to render it verbatim."""
     )],
     format: Annotated[Literal["4:3", "16:9"], Field(
         default="16:9",

--- a/middleware.py
+++ b/middleware.py
@@ -48,7 +48,13 @@ class ApiKeyAuthMiddleware(Middleware):
             raise ValueError("ApiKeyAuthMiddleware requires a non-empty expected_key")
         self.expected_key = expected_key
         self._failed_attempts: int = 0
-        self._last_warn_time: float = 0.0
+        # None means "no warning emitted yet". Do NOT use 0.0 as that sentinel:
+        # it is compared against time.monotonic(), whose epoch is the host boot
+        # on Linux, so on a freshly started pod "now - 0.0" is under the throttle
+        # interval and the very first auth failure would be silenced for up to
+        # _WARN_INTERVAL_SECONDS after boot — exactly when a misconfigured client
+        # is most likely to be hammering a new deployment.
+        self._last_warn_time: Optional[float] = None
 
     # ------------------------------------------------------------------
     # Key extraction
@@ -96,8 +102,10 @@ class ApiKeyAuthMiddleware(Middleware):
             # Always log at DEBUG (cheap, only visible when debug is on)
             logger.debug("Auth failure on %s (attempt #%d)", context.method, self._failed_attempts)
 
-            # Throttled WARNING: emit at most once per interval
-            if now - self._last_warn_time >= self._WARN_INTERVAL_SECONDS:
+            # Throttled WARNING: emit at most once per interval, and always on
+            # the first failure regardless of how long the process has been up.
+            if (self._last_warn_time is None
+                    or now - self._last_warn_time >= self._WARN_INTERVAL_SECONDS):
                 logger.warning(
                     "Rejected %d auth attempt(s) in the last %.0fs",
                     self._failed_attempts,

--- a/pptx_tools/__init__.py
+++ b/pptx_tools/__init__.py
@@ -1,7 +1,9 @@
 from .base_pptx_tool import create_presentation, _create_presentation_buffer
 from .slide_builder import PowerpointPresentation
 from .image_utils import download_image, ImageDownloadError, ImageValidationError
-from .chart_utils import add_chart_to_slide, CHART_TYPE_MAP, ChartDataError
+from .chart_utils import (
+    add_chart_to_slide, CHART_TYPE_MAP, UNSUPPORTED_CHART_TYPES, ChartDataError,
+)
 
 __all__ = [
     "create_presentation",
@@ -12,5 +14,6 @@ __all__ = [
     "ImageValidationError",
     "add_chart_to_slide",
     "CHART_TYPE_MAP",
+    "UNSUPPORTED_CHART_TYPES",
     "ChartDataError",
 ]

--- a/pptx_tools/base_pptx_tool.py
+++ b/pptx_tools/base_pptx_tool.py
@@ -3,6 +3,7 @@ import logging
 from typing import List, Dict, Any, Optional
 
 from upload_tools import upload_file
+from .constants import DEFAULT_SLIDE_FORMAT
 from .slide_builder import PowerpointPresentation
 
 logger = logging.getLogger(__name__)
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 def _create_presentation_buffer(
     slides: List[Dict[str, Any]],
-    format: str = "4:3",
+    format: str = DEFAULT_SLIDE_FORMAT,
     author: Optional[str] = None,
     footer_text: Optional[str] = None,
     show_slide_numbers: bool = False,
@@ -21,7 +22,7 @@ def _create_presentation_buffer(
     such as for LibreChat file artifact uploads.
 
     :param slides: List of slide dicts with keys based on slide_type
-    :param format: "4:3" or "16:9"
+    :param format: "4:3" or "16:9" (defaults to the shared DEFAULT_SLIDE_FORMAT)
     :param author: Author name for document properties
     :param footer_text: Optional footer text displayed on all slides
     :param show_slide_numbers: Whether to show slide numbers
@@ -43,7 +44,7 @@ def _create_presentation_buffer(
 
 def create_presentation(
     slides: List[Dict[str, Any]],
-    format: str = "4:3",
+    format: str = DEFAULT_SLIDE_FORMAT,
     file_name: Optional[str] = None,
     author: Optional[str] = None,
     footer_text: Optional[str] = None,

--- a/pptx_tools/chart_utils.py
+++ b/pptx_tools/chart_utils.py
@@ -13,7 +13,14 @@ from pptx.enum.chart import XL_CHART_TYPE, XL_LEGEND_POSITION
 logger = logging.getLogger(__name__)
 
 
-# Mapping of chart type strings to python-pptx chart types
+# Mapping of chart type strings to python-pptx chart types.
+#
+# Every entry here is category-based and is built from CategoryChartData.
+# 'scatter' (XY_SCATTER) is deliberately absent: an XY chart needs XyChartData
+# and (x, y) point pairs, so building one from categories+series raised
+# "'CategoryWorkbookWriter' object has no attribute 'x_values_ref'" on every
+# call. It was advertised in the tool description but could never succeed.
+# A dedicated scatter slide type with its own data shape is tracked separately.
 CHART_TYPE_MAP = {
     'bar': XL_CHART_TYPE.BAR_CLUSTERED,
     'bar_stacked': XL_CHART_TYPE.BAR_STACKED,
@@ -25,8 +32,17 @@ CHART_TYPE_MAP = {
     'doughnut': XL_CHART_TYPE.DOUGHNUT,
     'area': XL_CHART_TYPE.AREA,
     'area_stacked': XL_CHART_TYPE.AREA_STACKED,
-    'scatter': XL_CHART_TYPE.XY_SCATTER,
     'radar': XL_CHART_TYPE.RADAR,
+}
+
+# Chart types that are recognised but not supported, mapped to the advice shown
+# to the caller. Without this, 'scatter' would report only "Unknown chart type".
+UNSUPPORTED_CHART_TYPES = {
+    'scatter': (
+        "Scatter (XY) charts are not supported yet because they need (x, y) point "
+        "pairs rather than categories and series. Use 'line_markers' for a trend "
+        "over ordered categories."
+    ),
 }
 
 
@@ -48,15 +64,18 @@ def validate_chart_data(chart_data: Dict[str, Any], chart_type: str) -> None:
     if not chart_data:
         raise ChartDataError("Chart data is required")
 
+    if chart_type in UNSUPPORTED_CHART_TYPES:
+        raise ChartDataError(
+            f"{UNSUPPORTED_CHART_TYPES[chart_type]} Available: {', '.join(CHART_TYPE_MAP)}"
+        )
+
     if chart_type not in CHART_TYPE_MAP:
         raise ChartDataError(f"Unknown chart type: {chart_type}. Available: {', '.join(CHART_TYPE_MAP.keys())}")
 
-    # Scatter charts don't use categories
-    if chart_type != 'scatter':
-        if 'categories' not in chart_data:
-            raise ChartDataError("Chart data must include 'categories'")
-        if not chart_data['categories']:
-            raise ChartDataError("Categories list cannot be empty")
+    if 'categories' not in chart_data:
+        raise ChartDataError("Chart data must include 'categories'")
+    if not chart_data['categories']:
+        raise ChartDataError("Categories list cannot be empty")
 
     if 'series' not in chart_data:
         raise ChartDataError("Chart data must include 'series'")

--- a/pptx_tools/constants.py
+++ b/pptx_tools/constants.py
@@ -9,6 +9,20 @@ from pptx.dml.color import RGBColor
 
 
 # =============================================================================
+# Presentation Formats
+# =============================================================================
+# Single source of truth for the accepted aspect ratios. Previously the tool
+# handler defaulted to "16:9" while _create_presentation_buffer() defaulted to
+# "4:3", so a caller that omitted the argument got a different deck depending on
+# which entry point it used.
+
+SLIDE_FORMAT_4_3 = "4:3"
+SLIDE_FORMAT_16_9 = "16:9"
+VALID_SLIDE_FORMATS = (SLIDE_FORMAT_4_3, SLIDE_FORMAT_16_9)
+DEFAULT_SLIDE_FORMAT = SLIDE_FORMAT_16_9
+
+
+# =============================================================================
 # Slide Layout Indices (PowerPoint default template)
 # =============================================================================
 
@@ -25,11 +39,20 @@ BLANK_LAYOUT = 6           # Blank
 # Typography
 # =============================================================================
 
-DEFAULT_TITLE_FONT_SIZE = Pt(32)
 DEFAULT_SUBTITLE_FONT_SIZE = Pt(20)
 DEFAULT_BODY_FONT_SIZE = Pt(18)
 DEFAULT_CAPTION_FONT_SIZE = Pt(14)
 DEFAULT_QUOTE_FONT_SIZE = Pt(28)
+
+
+# =============================================================================
+# Bullet Indentation
+# =============================================================================
+# PowerPoint supports paragraph levels 0-8; the slide schema documents 1-3.
+# Values outside 1..MAX_INDENT_LEVEL are clamped rather than rejected, because a
+# model occasionally emits a deeper level than the prompt asked for.
+
+MAX_INDENT_LEVEL = 5
 
 
 # =============================================================================
@@ -46,8 +69,4 @@ TABLE_ALT_ROW_FILL = RGBColor(0xE9, 0xEC, 0xEF)
 # =============================================================================
 
 MARGIN_LEFT = Inches(0.5)
-MARGIN_TOP = Inches(0.3)
-MARGIN_BOTTOM = Inches(0.5)
-TITLE_HEIGHT = Inches(0.8)
-CONTENT_TOP = Inches(1.3)
 

--- a/pptx_tools/helpers.py
+++ b/pptx_tools/helpers.py
@@ -15,13 +15,13 @@ from pptx.dml.color import RGBColor
 from pptx.oxml import parse_xml
 
 from .constants import (
-    BLANK_LAYOUT, CONTENT_LAYOUT,
+    CONTENT_LAYOUT,
     DEFAULT_BODY_FONT_SIZE,
-    MARGIN_LEFT,
+    MARGIN_LEFT, MAX_INDENT_LEVEL,
     TABLE_HEADER_FILL, TABLE_HEADER_TEXT, TABLE_ALT_ROW_FILL,
 )
 from .image_utils import download_image, ImageDownloadError, ImageValidationError
-from .inline_formatting import has_inline_formatting, apply_inline_formatting
+from .inline_formatting import needs_inline_processing, apply_inline_formatting
 
 logger = logging.getLogger(__name__)
 
@@ -34,10 +34,28 @@ logger = logging.getLogger(__name__)
 _SEPARATOR_CELL_RE = re.compile(r'^\s*:?-{3,}:?\s*$')
 
 
+def cell_to_text(value: Any) -> str:
+    """Render one raw table cell as text.
+
+    Table data arrives straight from the model, which sends numbers as numbers
+    and omissions as ``null``. Everything downstream (the separator regex, the
+    cell writer) needs a string, so normalise here rather than at each use.
+
+    ``None`` becomes an empty cell; every other value is stringified, so a
+    numeric ``0`` survives as "0" instead of being dropped by a falsy test.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
 def _is_separator_row(row: List[str]) -> bool:
     """Check if a row is a markdown table separator row (e.g., |:---|:---:|---:|).
 
     Uses strict per-cell regex to avoid false positives on content containing dashes.
+    Expects cells already normalised to text by :func:`cell_to_text`.
     """
     return bool(row) and all(_SEPARATOR_CELL_RE.match(cell) for cell in row)
 
@@ -63,11 +81,15 @@ def _extract_alignments(row: List[str]) -> List[Optional[int]]:
     return alignments
 
 
-def parse_table_data(table_data: List[List[str]]) -> tuple:
+def parse_table_data(table_data: List[List[Any]]) -> tuple:
     """Clean table data by removing markdown separator rows and extracting alignments.
 
+    Cells are normalised to text first, so numeric and ``null`` cells are
+    accepted; previously they raised ``TypeError`` inside the separator regex
+    and failed the whole presentation.
+
     Args:
-        table_data: Raw table data as list of rows.
+        table_data: Raw table data as list of rows. Cells may be any scalar.
 
     Returns:
         Tuple of (cleaned_rows, column_alignments).
@@ -81,28 +103,63 @@ def parse_table_data(table_data: List[List[str]]) -> tuple:
     col_alignments = None
 
     for row in table_data:
-        if _is_separator_row(row):
-            col_alignments = _extract_alignments(row)
+        # A row sent as a bare scalar becomes a single-cell row rather than an error.
+        cells = [cell_to_text(c) for c in row] if isinstance(row, (list, tuple)) else [cell_to_text(row)]
+
+        if _is_separator_row(cells):
+            col_alignments = _extract_alignments(cells)
         else:
-            cleaned.append(row)
+            cleaned.append(cells)
 
     return cleaned, col_alignments
 
 
-def parse_color(color_hex: str, default: RGBColor) -> RGBColor:
-    """Parse hex color string to RGBColor.
+def parse_color(color_hex: Any, default: RGBColor) -> RGBColor:
+    """Parse a hex color string to RGBColor.
+
+    Accepts both "4172C4" and "#4172C4" — models routinely send the leading
+    hash, which ``RGBColor.from_string`` rejects. An unusable value falls back
+    to *default* and is logged at WARNING, because silently substituting a
+    colour is the kind of failure nobody notices until the deck is on screen.
 
     Args:
-        color_hex: Hex color string (e.g., "4172C4").
+        color_hex: Hex color string, with or without a leading '#'.
         default: Default color if parsing fails.
 
     Returns:
         RGBColor object.
     """
-    try:
-        return RGBColor.from_string(color_hex)
-    except (ValueError, AttributeError):
+    if color_hex is None:
         return default
+
+    try:
+        return RGBColor.from_string(str(color_hex).strip().lstrip('#').upper())
+    except (ValueError, AttributeError):
+        logger.warning(
+            "Unrecognised colour %r (expected 6-digit hex such as '4172C4' or '#4172C4'); using %s",
+            color_hex, default,
+        )
+        return default
+
+
+def coerce_indent_level(value: Any) -> int:
+    """Map a 1-based ``indentation_level`` onto a 0-based pptx paragraph level.
+
+    Tolerant by design: the value reaches us from a model, so a numeric string
+    ("2") is accepted, a level past the supported depth is clamped instead of
+    producing an invalid paragraph, and an unparseable value falls back to the
+    top level with a warning rather than failing the presentation.
+    """
+    if value is None:
+        return 0
+
+    try:
+        level = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid indentation_level %r; using 1", value)
+        level = 1
+
+    return max(1, min(level, MAX_INDENT_LEVEL)) - 1
 
 
 # =============================================================================
@@ -126,11 +183,6 @@ class SlideHelpers:
     def _get_slide_dimensions(self) -> Tuple[int, int]:
         """Get slide width and height."""
         return self.presentation.slide_width, self.presentation.slide_height
-
-    def _add_blank_slide(self):
-        """Add a blank slide and return it."""
-        layout = self.presentation.slide_layouts[BLANK_LAYOUT]
-        return self.presentation.slides.add_slide(layout)
 
     def _add_title_content_slide(self, title: str = ""):
         """Add a Title and Content slide and return slide with content placeholder info.
@@ -249,6 +301,9 @@ class SlideHelpers:
         **bold**, *italic*, ***bold italic***, ~~strikethrough~~,
         __underline__, `code`.
 
+        A bullet may also be given as a bare string, which is treated as
+        ``{"text": <string>}`` at the top level.
+
         Args:
             text_frame: PowerPoint text frame object (from placeholder or textbox).
             items: List of dicts with 'text' and 'indentation_level' keys.
@@ -260,50 +315,25 @@ class SlideHelpers:
         text_frame.word_wrap = True
 
         for i, item in enumerate(items):
+            if not isinstance(item, dict):
+                item = {"text": cell_to_text(item)}
+
             if i == 0:
                 para = text_frame.paragraphs[0]
             else:
                 para = text_frame.add_paragraph()
 
-            item_text = item.get("text", "")
+            item_text = cell_to_text(item.get("text", ""))
             para.alignment = PP_ALIGN.LEFT
-            para.level = max(0, int(item.get("indentation_level", 1)) - 1)
+            para.level = coerce_indent_level(item.get("indentation_level", 1))
 
-            # Apply inline markdown formatting if markers are present
-            if has_inline_formatting(item_text):
+            # Apply inline markdown formatting when markers OR escapes are present
+            if needs_inline_processing(item_text):
                 apply_inline_formatting(para, item_text, font_size=font_size)
             else:
                 para.text = item_text
                 if font_size:
                     para.font.size = font_size
-
-    def _add_bullet_list(
-        self,
-        slide,
-        items: List[dict],
-        left: int,
-        top: int,
-        width: int,
-        height: int,
-        font_size: Optional[int] = None
-    ):
-        """Add a bullet list textbox to a slide.
-
-        Args:
-            slide: PowerPoint slide object.
-            items: List of dicts with 'text' and 'indentation_level' keys.
-            left, top, width, height: Position and size.
-            font_size: Font size for items.
-
-        Returns:
-            Created textbox shape or None if no items.
-        """
-        if not items:
-            return None
-
-        shape = slide.shapes.add_textbox(left, top, width, height)
-        self._fill_bullets(shape.text_frame, items, font_size)
-        return shape
 
     # -------------------------------------------------------------------------
     # Table Helpers
@@ -378,7 +408,8 @@ class SlideHelpers:
                     continue
 
                 cell = table.cell(row_idx, col_idx)
-                cell.text = str(cell_text) if cell_text else ""
+                # cell_to_text, not a falsy test: `if cell_text` blanked a numeric 0.
+                cell.text = cell_to_text(cell_text)
 
                 # Apply column alignment
                 if column_alignments and col_idx < len(column_alignments):

--- a/pptx_tools/inline_formatting.py
+++ b/pptx_tools/inline_formatting.py
@@ -41,7 +41,15 @@ _INLINE_FORMAT_RE = re.compile(
     # __underline__
     r'|__(?=[^\s_]).+?(?<=[^\s_])__'
     # *italic* (allows nested **bold**)
-    r'|\*(?=[^\s*])(?:[^*]|\*\*[^*]+\*\*)+?(?<=[^\s*])\*'
+    #
+    # The other branches close on a lookbehind, but this one cannot: a nested
+    # **bold** unit ends in '*', so a lookbehind would reject an italic span
+    # whose last element is bold with nothing between the two closers
+    # ("*always **backup your data***") and the outer italic would be dropped,
+    # leaving stray asterisks on the slide. Instead the right flank is stated
+    # structurally: whatever is consumed last must itself be a valid flank —
+    # a non-space non-star character, or a complete nested bold unit.
+    r'|\*(?=[^\s*])(?:[^*]|\*\*[^*]+\*\*)*?(?:[^\s*]|\*\*[^*]+\*\*)\*'
     # `code`
     r'|`[^`]+`)'
 )

--- a/pptx_tools/inline_formatting.py
+++ b/pptx_tools/inline_formatting.py
@@ -17,15 +17,33 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Inline formatting regex (subset of docx_tools/patterns.py)
 # Covers the formats that render well in PowerPoint.
+#
+# Every marker is "flanked": the opening marker must be followed by a character
+# that is neither whitespace nor another marker character, and the closing
+# marker must be preceded by one. This mirrors CommonMark's left/right-flanking
+# delimiter rules and is what keeps prose such as "5 * 3 * 2 = 30" or
+# "10 ~ 20 ~ 30" from being read as emphasis. Without it, the italic branch
+# matched "* 3 *" and italicised the 3.
+#
+# Note on dunders: "__init__" is emphasis under standard markdown too (the
+# opening and closing markers are both flanked), so it is matched here as well.
+# Write it inside backticks — `__init__` — to render it verbatim; the code
+# branch consumes the span before any emphasis branch sees it.
 # ---------------------------------------------------------------------------
 
 _INLINE_FORMAT_RE = re.compile(
-    r'(\*{3}(?:[^*]|\*(?!\*{2}))+\*{3}'  # ***bold italic***
-    r'|\*\*(?:[^*]|\*(?!\*))+\*\*'       # **bold**
-    r'|~~.+?~~'                           # ~~strikethrough~~
-    r'|__(?!_).+?__'                      # __underline__
-    r'|\*(?:[^*]|\*\*[^*]+\*\*)+\*'       # *italic* (allows nested **bold**)
-    r'|`[^`]+`)'                          # `code`
+    # ***bold italic***
+    r'(\*{3}(?=[^\s*])(?:[^*]|\*(?!\*{2}))+?(?<=[^\s*])\*{3}'
+    # **bold**
+    r'|\*\*(?=[^\s*])(?:[^*]|\*(?!\*))+?(?<=[^\s*])\*\*'
+    # ~~strikethrough~~
+    r'|~~(?=[^\s~]).+?(?<=[^\s~])~~'
+    # __underline__
+    r'|__(?=[^\s_]).+?(?<=[^\s_])__'
+    # *italic* (allows nested **bold**)
+    r'|\*(?=[^\s*])(?:[^*]|\*\*[^*]+\*\*)+?(?<=[^\s*])\*'
+    # `code`
+    r'|`[^`]+`)'
 )
 
 _ESCAPE_RE = re.compile(r'\\(.)')  # backslash-escaped character
@@ -38,6 +56,22 @@ _ESCAPE_RE = re.compile(r'\\(.)')  # backslash-escaped character
 def has_inline_formatting(text: str) -> bool:
     """Quick check whether text contains any inline markdown markers."""
     return bool(_INLINE_FORMAT_RE.search(text))
+
+
+def has_escapes(text: str) -> bool:
+    """Quick check whether text contains a backslash escape."""
+    return bool(_ESCAPE_RE.search(text))
+
+
+def needs_inline_processing(text: str) -> bool:
+    """True when *text* must go through :func:`apply_inline_formatting`.
+
+    Callers used to test :func:`has_inline_formatting` alone and assign
+    ``paragraph.text`` directly otherwise. That skipped the escape pass, so
+    text carrying only an escape and no live marker (``price \\* qty``) kept its
+    backslash. Escapes are now honoured whether or not the text also formats.
+    """
+    return has_inline_formatting(text) or has_escapes(text)
 
 
 def apply_inline_formatting(

--- a/pptx_tools/slide_builder.py
+++ b/pptx_tools/slide_builder.py
@@ -21,12 +21,13 @@ from .constants import (
     TWO_COLUMN_LAYOUT, TWO_COLUMN_TEXT_LAYOUT,
     DEFAULT_SUBTITLE_FONT_SIZE, DEFAULT_CAPTION_FONT_SIZE, DEFAULT_QUOTE_FONT_SIZE,
     TABLE_HEADER_FILL,
+    DEFAULT_SLIDE_FORMAT, SLIDE_FORMAT_16_9, VALID_SLIDE_FORMATS,
 )
 from .helpers import (
     SlideHelpers,
     parse_table_data, parse_color,
 )
-from .inline_formatting import has_inline_formatting, apply_inline_formatting
+from .inline_formatting import needs_inline_processing, apply_inline_formatting
 from .chart_utils import add_chart_to_slide, ChartDataError
 
 logger = logging.getLogger(__name__)
@@ -76,7 +77,7 @@ class PowerpointPresentation(SlideHelpers):
         self.presentation = self._create_presentation(format)
         self._footer_text = footer_text
         self._show_slide_numbers = show_slide_numbers
-        self._remove_default_slide()
+        self._remove_template_slides()
         self._build_slides(slides)
         if footer_text or show_slide_numbers:
             self._apply_footer_and_slide_numbers()
@@ -92,8 +93,15 @@ class PowerpointPresentation(SlideHelpers):
         Returns:
             Presentation object.
         """
+        if format not in VALID_SLIDE_FORMATS:
+            logger.warning(
+                "Unknown presentation format %r; using %s. Valid formats: %s",
+                format, DEFAULT_SLIDE_FORMAT, ", ".join(VALID_SLIDE_FORMATS),
+            )
+            format = DEFAULT_SLIDE_FORMAT
+
         template_4_3, template_16_9 = _get_templates()
-        template = template_16_9 if format == "16:9" else template_4_3
+        template = template_16_9 if format == SLIDE_FORMAT_16_9 else template_4_3
 
         if template:
             try:
@@ -104,15 +112,31 @@ class PowerpointPresentation(SlideHelpers):
         logger.warning(f"Using default PowerPoint template for {format}")
         return Presentation()
 
-    def _remove_default_slide(self) -> None:
-        """Remove default slide if present."""
-        if len(self.presentation.slides) > 0:
+    def _remove_template_slides(self) -> None:
+        """Remove every slide the template ships with, parts included.
+
+        Dropping only the ``<p:sldId>`` entry (what this did previously) leaves
+        the slide's relationship in place, and python-pptx serialises parts by
+        walking relationships — so a template carrying a sample slide shipped
+        that slide's XML, text and images inside every generated file even
+        though PowerPoint showed the right slide count. Dropping the
+        relationship as well removes the part from the saved package.
+        """
+        sldIdLst = self.presentation.slides._sldIdLst
+        prs_part = self.presentation.part
+
+        removed = 0
+        for sldId in list(sldIdLst):
+            rId = sldId.rId
             try:
-                slide = self.presentation.slides[0]
-                self.presentation.slides.element.remove(slide.element)
-                logger.debug("Removed default slide")
+                sldIdLst.remove(sldId)
+                prs_part.drop_rel(rId)
+                removed += 1
             except Exception as e:
-                logger.debug(f"Could not remove default slide: {e}")
+                logger.warning("Could not fully remove template slide %s: %s", rId, e)
+
+        if removed:
+            logger.debug("Removed %d slide(s) carried by the template", removed)
 
     def _build_slides(self, slides: List[Dict[str, Any]]) -> None:
         """Build all slides from data.
@@ -134,18 +158,30 @@ class PowerpointPresentation(SlideHelpers):
         logger.info(f"Building {len(slides)} slides")
 
         for i, slide_data in enumerate(slides):
+            if not isinstance(slide_data, dict):
+                raise ValueError(
+                    f"Slide {i} must be an object with a 'slide_type' field, got {type(slide_data).__name__}"
+                )
+
             slide_type = slide_data.get("slide_type", "")
             builder = slide_builders.get(slide_type)
 
-            if builder:
-                try:
-                    logger.debug(f"Building slide {i}: type={slide_type}")
-                    builder(slide_data)
-                except Exception as e:
-                    logger.error(f"Failed to create slide {i}: {e}")
-                    raise ValueError(f"Error creating slide {i} ({slide_type}): {e}")
-            else:
-                logger.warning(f"Unknown slide type '{slide_type}' at index {i}")
+            if builder is None:
+                # Previously this only logged a warning: the slide was dropped and
+                # the caller still received a success response quoting the number
+                # of slides it had asked for. Fail loudly so the model can correct
+                # the type instead of shipping a deck with holes in it.
+                raise ValueError(
+                    f"Unknown slide_type {slide_type!r} at slide {i}. "
+                    f"Valid types: {', '.join(sorted(slide_builders))}"
+                )
+
+            try:
+                logger.debug(f"Building slide {i}: type={slide_type}")
+                builder(slide_data)
+            except Exception as e:
+                logger.error(f"Failed to create slide {i}: {e}")
+                raise ValueError(f"Error creating slide {i} ({slide_type}): {e}")
 
     # -------------------------------------------------------------------------
     # Slide Builders
@@ -369,7 +405,7 @@ class PowerpointPresentation(SlideHelpers):
         para = tf.paragraphs[0]
         para.alignment = PP_ALIGN.CENTER
         formatted_quote = f'"{quote_text}"'
-        if has_inline_formatting(formatted_quote):
+        if needs_inline_processing(formatted_quote):
             apply_inline_formatting(para, formatted_quote,
                                     font_size=DEFAULT_QUOTE_FONT_SIZE, italic=True)
         else:
@@ -405,12 +441,8 @@ class PowerpointPresentation(SlideHelpers):
             layout = slide.slide_layout
             spTree = slide.shapes._spTree
 
-            # Determine next available shape ID on this slide
-            existing_ids = {
-                int(sp.get('id', 0))
-                for sp in spTree.findall(qn('p:sp') + '//' + qn('p:cNvPr'))
-            }
-            # Simpler: collect all id attributes from direct children
+            # Determine next available shape ID on this slide by collecting the
+            # id attributes of the tree's direct children.
             existing_ids = set()
             for sp in spTree:
                 cNvPr = sp.find('.//' + qn('p:cNvPr'))

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -270,7 +270,7 @@ class TestOnRequest:
         # First failure triggers a WARNING which resets counter to 0
         # so after one reject the counter is 0 (just emitted warning)
         assert mw._failed_attempts == 0
-        assert mw._last_warn_time > 0
+        assert mw._last_warn_time is not None
 
     async def test_throttled_warning_not_emitted_within_interval(self):
         """WARNING should NOT fire again within the throttle window."""
@@ -300,8 +300,12 @@ class TestOnRequest:
         call_next = AsyncMock()
         context = _make_context()
 
-        # Pretend the last warning was long ago
-        mw._last_warn_time = 0.0
+        # Pretend the last warning was long ago. Anchor this to the current
+        # monotonic reading rather than hard-coding 0.0: monotonic counts from
+        # host boot, so on a freshly booted runner 0.0 is *within* the throttle
+        # window, not before it.
+        import time as _time
+        mw._last_warn_time = _time.monotonic() - mw._WARN_INTERVAL_SECONDS - 1
         mw._failed_attempts = 5  # accumulated silently
 
         with patch("middleware.get_http_headers", return_value={}), \
@@ -312,6 +316,29 @@ class TestOnRequest:
         # WARNING should have been emitted (interval elapsed)
         mock_logger.warning.assert_called_once()
         # Counter should reset after warning
+        assert mw._failed_attempts == 0
+
+    async def test_first_warning_emitted_on_a_freshly_booted_host(self):
+        """The first auth failure warns even seconds after boot.
+
+        time.monotonic() counts from host boot on Linux, so while a 0.0
+        sentinel was used for "never warned", `now - 0.0` stayed inside the
+        throttle window for the first minute of uptime and the very first
+        warning was swallowed — on a new pod, precisely when a misconfigured
+        client is most likely to be hammering it.
+        """
+        mw = ApiKeyAuthMiddleware("secret-123")
+        call_next = AsyncMock()
+        context = _make_context()
+
+        # Host booted 12 seconds ago, well inside _WARN_INTERVAL_SECONDS.
+        with patch("middleware.get_http_headers", return_value={"x-api-key": "wrong"}), \
+             patch("middleware.time.monotonic", return_value=12.0), \
+             patch("middleware.logger") as mock_logger:
+            with pytest.raises(AuthorizationError):
+                await mw.on_request(context, call_next)
+
+        mock_logger.warning.assert_called_once()
         assert mw._failed_attempts == 0
 
 

--- a/tests/test_pptx_robustness.py
+++ b/tests/test_pptx_robustness.py
@@ -214,6 +214,40 @@ class TestInlineFormattingPrecision:
         assert any(run.font.italic and run.text == "italic" for run in runs)
         assert any(run.font.name == "Courier New" and run.text == "code" for run in runs)
 
+    def test_italic_span_ending_in_bold(self):
+        """An italic whose last word is bold, with the closers touching.
+
+        The flanking rules first shipped here closed the italic branch on a
+        lookbehind, which a nested bold unit fails because it ends in '*'. The
+        outer italic was dropped and its asterisks rendered literally on the
+        slide. Reported in review of #101.
+        """
+        pres = build([{
+            "slide_type": "content",
+            "slide_title": "Nested",
+            "slide_text": [{"text": "*Remember, always **backup your data***", "indentation_level": 1}],
+        }])
+        paragraph = body_paragraphs(reload_presentation(pres).slides[0])[0]
+
+        assert "*" not in paragraph.text, f"stray asterisks rendered: {paragraph.text!r}"
+        assert paragraph.text == "Remember, always backup your data"
+        # Every run italic; the trailing phrase additionally bold.
+        assert all(run.font.italic for run in paragraph.runs)
+        assert any(run.font.bold and run.text == "backup your data" for run in paragraph.runs)
+
+    def test_italic_span_with_bold_not_touching_the_close(self):
+        """The neighbouring case that already worked must keep working."""
+        pres = build([{
+            "slide_type": "content",
+            "slide_title": "Nested",
+            "slide_text": [{"text": "*italic with **bold** inside*", "indentation_level": 1}],
+        }])
+        paragraph = body_paragraphs(reload_presentation(pres).slides[0])[0]
+
+        assert paragraph.text == "italic with bold inside"
+        assert all(run.font.italic for run in paragraph.runs)
+        assert any(run.font.bold and run.text == "bold" for run in paragraph.runs)
+
     def test_backticks_protect_a_dunder(self):
         """`__init__` in backticks renders verbatim rather than underlined."""
         pres = build([{

--- a/tests/test_pptx_robustness.py
+++ b/tests/test_pptx_robustness.py
@@ -1,0 +1,378 @@
+"""Regression tests for PowerPoint input handling (review Phase 0).
+
+Each test here pins down a failure that reached a user: a crash on input a
+model plausibly sends, or — worse — a deck that came back wrong with a success
+response. Unlike test_pptx_creation.py these assert on the built presentation,
+not merely that a file appeared on disk.
+"""
+
+import io
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+# Add project root to path for imports
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import pytest
+from pptx import Presentation as PptxReader
+from pptx.dml.color import RGBColor
+
+from pptx_tools import slide_builder
+from pptx_tools.chart_utils import CHART_TYPE_MAP, ChartDataError, validate_chart_data
+from pptx_tools.constants import DEFAULT_SLIDE_FORMAT, TABLE_HEADER_FILL
+from pptx_tools.helpers import cell_to_text, coerce_indent_level, parse_color, parse_table_data
+from pptx_tools.inline_formatting import needs_inline_processing
+from pptx_tools.slide_builder import PowerpointPresentation
+
+_SLIDE_PART_RE = re.compile(r"^ppt/slides/slide\d+\.xml$")
+
+
+def build(slides, fmt="16:9", **kwargs) -> PowerpointPresentation:
+    """Build a presentation in memory."""
+    return PowerpointPresentation(slides, fmt, **kwargs)
+
+
+def reload_presentation(pres: PowerpointPresentation):
+    """Round-trip through the saved bytes, as PowerPoint would see it."""
+    buffer = pres.save()
+    return PptxReader(buffer)
+
+
+def first_table(slide):
+    for shape in slide.shapes:
+        if getattr(shape, "has_table", False):
+            return shape.table
+    raise AssertionError("No table on slide")
+
+
+def body_paragraphs(slide, exclude_title=True):
+    """Paragraphs of the first non-title text frame carrying text."""
+    for shape in slide.shapes:
+        if not shape.has_text_frame:
+            continue
+        if exclude_title and shape.is_placeholder and shape.placeholder_format.idx == 0:
+            continue
+        if shape.text_frame.text.strip():
+            return shape.text_frame.paragraphs
+    raise AssertionError("No body text frame on slide")
+
+
+# =============================================================================
+# Table cell coercion
+# =============================================================================
+
+class TestTableCellCoercion:
+    """Numbers and nulls in table_data used to fail the whole presentation."""
+
+    def test_numeric_cells_are_rendered(self):
+        pres = build([{
+            "slide_type": "table",
+            "slide_title": "Numbers",
+            "table_data": [["Item", "Qty", "Price"], ["Widget", 12, 9.99]],
+        }])
+        table = first_table(reload_presentation(pres).slides[0])
+        assert table.cell(1, 1).text == "12"
+        assert table.cell(1, 2).text == "9.99"
+
+    def test_zero_is_not_blanked(self):
+        """`if cell_text` treated a numeric 0 as empty and dropped it."""
+        pres = build([{
+            "slide_type": "table",
+            "slide_title": "Zero",
+            "table_data": [["Region", "Sales"], ["North", 0], ["South", "0"]],
+        }])
+        table = first_table(reload_presentation(pres).slides[0])
+        assert table.cell(1, 1).text == "0"
+        assert table.cell(2, 1).text == "0"
+
+    def test_none_cell_becomes_empty_string(self):
+        pres = build([{
+            "slide_type": "table",
+            "slide_title": "Missing",
+            "table_data": [["A", "B"], [None, "y"]],
+        }])
+        table = first_table(reload_presentation(pres).slides[0])
+        assert table.cell(1, 0).text == ""
+        assert table.cell(1, 1).text == "y"
+
+    def test_separator_row_still_sets_alignment_with_mixed_cells(self):
+        rows, alignments = parse_table_data([["A", "B"], [":---", "---:"], [1, None]])
+        assert rows == [["A", "B"], ["1", ""]]
+        assert alignments is not None and len(alignments) == 2
+
+    def test_cell_to_text(self):
+        assert cell_to_text(None) == ""
+        assert cell_to_text(0) == "0"
+        assert cell_to_text(False) == "False"
+        assert cell_to_text("x") == "x"
+
+
+# =============================================================================
+# Unknown slide types
+# =============================================================================
+
+class TestUnknownSlideType:
+    """An unknown type used to be dropped while the caller was told it built."""
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(ValueError) as excinfo:
+            build([
+                {"slide_type": "title", "slide_title": "Deck"},
+                {"slide_type": "bullets", "slide_title": "Oops"},
+            ])
+        message = str(excinfo.value)
+        assert "bullets" in message
+        assert "slide 1" in message
+        # The message must list what the model should have used instead.
+        assert "content" in message and "two_column" in message
+
+    def test_no_slides_are_silently_dropped(self):
+        slides = [
+            {"slide_type": "title", "slide_title": "Deck"},
+            {"slide_type": "section", "slide_title": "Part 1"},
+            {"slide_type": "content", "slide_title": "Body",
+             "slide_text": [{"text": "a", "indentation_level": 1}]},
+        ]
+        pres = build(slides)
+        assert len(reload_presentation(pres).slides) == len(slides)
+
+    def test_non_dict_slide_raises(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            build(["just a string"])
+
+
+# =============================================================================
+# Colours
+# =============================================================================
+
+class TestHeaderColor:
+
+    def test_hash_prefixed_hex_is_accepted(self):
+        assert parse_color("#C00000", TABLE_HEADER_FILL) == RGBColor.from_string("C00000")
+
+    def test_bare_hex_still_accepted(self):
+        assert parse_color("c00000", TABLE_HEADER_FILL) == RGBColor.from_string("C00000")
+
+    def test_unparseable_falls_back_with_warning(self, caplog):
+        assert parse_color("cornflower", TABLE_HEADER_FILL) == TABLE_HEADER_FILL
+        assert "Unrecognised colour" in caplog.text
+
+    def test_hash_prefixed_header_reaches_the_table(self):
+        pres = build([{
+            "slide_type": "table",
+            "slide_title": "Branded",
+            "table_data": [["A", "B"], ["1", "2"]],
+            "header_color": "#C00000",
+        }])
+        table = first_table(reload_presentation(pres).slides[0])
+        fill_xml = table.cell(0, 0)._tc.get_or_add_tcPr().xml
+        assert "C00000" in fill_xml
+
+
+# =============================================================================
+# Inline formatting
+# =============================================================================
+
+class TestInlineFormattingPrecision:
+
+    def test_escape_without_other_markers_is_honoured(self):
+        """`price \\* qty` used to keep its backslash: the escape pass was skipped."""
+        pres = build([{
+            "slide_type": "content",
+            "slide_title": "Escapes",
+            "slide_text": [{"text": r"price \* qty", "indentation_level": 1}],
+        }])
+        paragraphs = body_paragraphs(reload_presentation(pres).slides[0])
+        assert paragraphs[0].text == "price * qty"
+        assert not any(run.font.italic for run in paragraphs[0].runs)
+
+    def test_arithmetic_is_not_italicised(self):
+        pres = build([{
+            "slide_type": "content",
+            "slide_title": "Math",
+            "slide_text": [{"text": "5 * 3 * 2 = 30", "indentation_level": 1}],
+        }])
+        paragraphs = body_paragraphs(reload_presentation(pres).slides[0])
+        assert paragraphs[0].text == "5 * 3 * 2 = 30"
+        assert not any(run.font.italic for run in paragraphs[0].runs)
+
+    def test_spaced_markers_do_not_format(self):
+        assert not needs_inline_processing("10 ~ 20 ~ 30")
+        assert not needs_inline_processing("a * b")
+
+    def test_hugging_markers_still_format(self):
+        pres = build([{
+            "slide_type": "content",
+            "slide_title": "Formatting",
+            "slide_text": [{"text": "**bold** and *italic* and `code`", "indentation_level": 1}],
+        }])
+        runs = body_paragraphs(reload_presentation(pres).slides[0])[0].runs
+        assert any(run.font.bold and run.text == "bold" for run in runs)
+        assert any(run.font.italic and run.text == "italic" for run in runs)
+        assert any(run.font.name == "Courier New" and run.text == "code" for run in runs)
+
+    def test_backticks_protect_a_dunder(self):
+        """`__init__` in backticks renders verbatim rather than underlined."""
+        pres = build([{
+            "slide_type": "content",
+            "slide_title": "Code",
+            "slide_text": [{"text": "call `__init__` first", "indentation_level": 1}],
+        }])
+        runs = body_paragraphs(reload_presentation(pres).slides[0])[0].runs
+        dunder = [run for run in runs if run.text == "__init__"]
+        assert dunder, "expected a run carrying the literal dunder"
+        assert not dunder[0].font.underline
+
+
+# =============================================================================
+# Indentation levels
+# =============================================================================
+
+class TestIndentationLevel:
+
+    @pytest.mark.parametrize("value,expected", [
+        (1, 0), (2, 1), ("2", 1), (None, 0),
+        (7, 4),      # clamped to MAX_INDENT_LEVEL
+        (0, 0), (-3, 0),
+        ("two", 0),  # unparseable -> top level
+    ])
+    def test_coercion(self, value, expected):
+        assert coerce_indent_level(value) == expected
+
+    def test_string_level_does_not_fail_the_deck(self):
+        pres = build([{
+            "slide_type": "content",
+            "slide_title": "Levels",
+            "slide_text": [
+                {"text": "top", "indentation_level": "1"},
+                {"text": "nested", "indentation_level": "2"},
+                {"text": "very deep", "indentation_level": 9},
+                {"text": "no level given"},
+            ],
+        }])
+        paragraphs = body_paragraphs(reload_presentation(pres).slides[0])
+        assert [p.level for p in paragraphs[:4]] == [0, 1, 4, 0]
+
+    def test_bare_string_bullet_is_accepted(self):
+        pres = build([{
+            "slide_type": "content",
+            "slide_title": "Plain list",
+            "slide_text": ["first", "second"],
+        }])
+        paragraphs = body_paragraphs(reload_presentation(pres).slides[0])
+        assert [p.text for p in paragraphs[:2]] == ["first", "second"]
+
+
+# =============================================================================
+# Charts
+# =============================================================================
+
+class TestChartTypes:
+
+    def test_scatter_is_rejected_with_advice(self):
+        with pytest.raises(ChartDataError) as excinfo:
+            validate_chart_data(
+                {"categories": ["a"], "series": [{"name": "s", "values": [1]}]}, "scatter"
+            )
+        message = str(excinfo.value)
+        assert "not supported" in message
+        assert "line_markers" in message
+
+    def test_scatter_is_not_advertised(self):
+        assert "scatter" not in CHART_TYPE_MAP
+
+    def test_supported_chart_still_builds(self):
+        pres = build([{
+            "slide_type": "chart",
+            "slide_title": "Revenue",
+            "chart_type": "column",
+            "chart_data": {"categories": ["Q1", "Q2"], "series": [{"name": "2026", "values": [1, 2]}]},
+        }])
+        slide = reload_presentation(pres).slides[0]
+        assert any(shape.has_chart for shape in slide.shapes)
+
+
+# =============================================================================
+# Template handling
+# =============================================================================
+
+@pytest.fixture
+def template_with_sample_slide(tmp_path):
+    """A template carrying two sample slides, as a designer would hand over."""
+    source = PptxReader(str(project_root / "default_templates" / "default_pptx_template_16_9.pptx"))
+    for index, text in ((1, "SAMPLE SLIDE ONE"), (2, "SAMPLE SLIDE TWO")):
+        slide = source.slides.add_slide(source.slide_layouts[index])
+        slide.shapes.title.text = text
+
+    path = tmp_path / "custom_pptx_template_16_9.pptx"
+    source.save(str(path))
+    return path
+
+
+@pytest.fixture
+def use_template(monkeypatch):
+    """Point the builder at a specific template file, bypassing the cache."""
+    def _use(path):
+        slide_builder._template_cache.clear()
+        monkeypatch.setattr(slide_builder, "find_pptx_templates", lambda: (str(path), str(path)))
+    yield _use
+    slide_builder._template_cache.clear()
+
+
+class TestTemplateSlideRemoval:
+
+    def test_sample_slides_do_not_ship_in_the_output(self, template_with_sample_slide, use_template):
+        use_template(template_with_sample_slide)
+
+        pres = build([{"slide_type": "title", "slide_title": "Real deck"}])
+        buffer = pres.save()
+
+        package = zipfile.ZipFile(buffer)
+        slide_parts = [name for name in package.namelist() if _SLIDE_PART_RE.match(name)]
+        assert len(slide_parts) == 1, f"orphan slide parts left in package: {slide_parts}"
+
+        blob = b"".join(package.read(name) for name in slide_parts)
+        assert b"SAMPLE SLIDE" not in blob
+
+    def test_slide_count_matches_the_request(self, template_with_sample_slide, use_template):
+        use_template(template_with_sample_slide)
+
+        pres = build([
+            {"slide_type": "title", "slide_title": "Real deck"},
+            {"slide_type": "section", "slide_title": "Part 1"},
+        ])
+        assert len(reload_presentation(pres).slides) == 2
+
+
+# =============================================================================
+# Format defaults
+# =============================================================================
+
+class TestFormatDefault:
+
+    def test_entry_points_share_one_default(self):
+        """main.py defaulted to 16:9 while the buffer helper defaulted to 4:3."""
+        import inspect
+
+        from pptx_tools.base_pptx_tool import _create_presentation_buffer, create_presentation
+
+        for func in (_create_presentation_buffer, create_presentation):
+            assert inspect.signature(func).parameters["format"].default == DEFAULT_SLIDE_FORMAT
+
+    def test_unknown_format_falls_back_to_default(self, caplog):
+        pres = build([{"slide_type": "title", "slide_title": "T"}], fmt="widescreen")
+        default_pres = build([{"slide_type": "title", "slide_title": "T"}], fmt=DEFAULT_SLIDE_FORMAT)
+        assert pres.presentation.slide_width == default_pres.presentation.slide_width
+        assert "Unknown presentation format" in caplog.text
+
+
+def test_buffer_is_a_readable_pptx():
+    """The saved buffer opens as a presentation and is positioned at the start."""
+    pres = build([{"slide_type": "title", "slide_title": "Round trip"}])
+    buffer = pres.save()
+    assert isinstance(buffer, io.BytesIO)
+    assert buffer.tell() == 0
+    assert len(PptxReader(buffer).slides) == 1


### PR DESCRIPTION
Closes #97. Part of #96.

**First PR in a stack.** Phases 1–3 branch off this one, so review and merge this first; each later phase rebases onto it.

| Stack | Issue | Status |
|---|---|---|
| **Phase 0 — stop the bleeding** | #97 | **this PR** |
| Phase 1 — typed slide schema | #98 | branches off this |
| Phase 2 — template registry | #99 | after Phase 1 |
| Phase 3 — new slide types, admin UI | #100 | after Phase 2 |

No schema change here, so prompts written against the current `slide_type` / `slide_title` / `slide_text` keys keep working. Every fix is behaviour-preserving for input that was already valid.

Three commits: the pptx work, an auth fix that enabling CI turned up, and a regression fix from review. Both of the latter are described at the bottom.

## Crashes and corrupt output

**Numbers and nulls in `table_data`.** Cells are normalised to text before the separator-row regex sees them. `[["A","B"],[0, 12.5]]` used to fail the whole presentation with *expected string or bytes-like object, got 'int'*. A numeric `0` is now written as `"0"` instead of being dropped by the falsy test in the cell writer.

**Sample slides leaked into every output.** `_remove_default_slide` dropped the `<p:sldId>` entry but left the relationship, and python-pptx serialises parts by walking relationships. A template carrying a sample slide shipped that slide's XML, text and images inside every generated file, even though PowerPoint showed the right slide count. Renamed to `_remove_template_slides`, it now drops the relationship as well and handles a template with more than one slide.

```
before: slide parts in package: ['ppt/slides/slide1.xml', 'ppt/slides/slide2.xml']  SAMPLE present: True
after:  slide parts in package: ['ppt/slides/slide1.xml']                           SAMPLE present: False
```

**`indentation_level` variants.** Numeric strings are accepted, out-of-range values clamp to the supported depth, and an unparseable value falls back to the top level with a warning instead of failing the deck. A bare string in `slide_text` is read as its text.

## Silent wrong output

**Unknown `slide_type` vanished.** It was skipped with a log warning while the caller got a success response quoting the number of slides it had asked for. It now raises with the valid types listed, so the model can correct itself:

```
Unknown slide_type 'bullets' at slide 1. Valid types: chart, content, image, quote, section, table, title, two_column
```

Since every slide now either builds or raises, the count in the success message equals the number of slides actually built, which is what #97 asked for.

**`header_color: "#C00000"`** was silently replaced by the default blue. `parse_color` strips a leading `#` and logs a warning when a value is genuinely unusable.

**Escapes were skipped on plain text.** The bullet renderer only ran the escape pass when the text also contained a live formatting marker, so `price \* qty` kept its backslash. Escapes are now honoured either way.

**Emphasis fired on ordinary prose.** Markers must hug their text, matching CommonMark's flanking rules, so `5 * 3 * 2 = 30` is no longer italicised on the `3`.

One deviation from the issue checklist worth calling out: `__init__` still matches. It is emphasis under standard markdown too, since both markers are flanked, and it is not distinguishable from `__underline__` at the token level. The remedy is backticks, which already work because the code branch consumes the span before any emphasis branch sees it. There is a test pinning that. I updated #97 to reflect this rather than leave the box implying an unshipped fix.

**`scatter` could never build.** An XY chart needs `XyChartData` and (x, y) pairs, so building one from categories and series raised `'CategoryWorkbookWriter' object has no attribute 'x_values_ref'` on every call, while the tool description advertised it. Removed from `CHART_TYPE_MAP` and the description; callers get an explanatory error naming `line_markers` as the alternative. A real scatter slide type with its own data shape is scoped to #98.

## Cleanup

- One shared `DEFAULT_SLIDE_FORMAT`. The tool handler defaulted to `16:9` while `_create_presentation_buffer` defaulted to `4:3`, so the deck depended on which entry point you used. An unrecognised value warns instead of quietly meaning 4:3.
- Removed `_add_bullet_list`, `_add_blank_slide`, `DEFAULT_TITLE_FONT_SIZE`, `MARGIN_TOP`, `MARGIN_BOTTOM`, `TITLE_HEIGHT`, `CONTENT_TOP`, and a duplicated shape-id scan whose first result was immediately discarded. The layout-index constants stay: they document the shipped template and Phase 2 replaces them wholesale.

## CI

The workflow ran on `workflow_dispatch` only and installed `requirements.txt`, but `ruff` and `pytest` live in `requirements-dev.txt` — both steps would have run without their tool. Enabling it on push and pull request meant fixing that first. Network-marked tests are deselected so a third-party image host cannot fail an unrelated PR.

## Second commit: `fix(auth)`, surfaced by turning CI on

The first CI run went red in `tests/test_auth_middleware.py`, which this PR does not otherwise touch. It is a genuine bug that had simply never run in CI before.

`ApiKeyAuthMiddleware._last_warn_time` used `0.0` as its "no warning emitted yet" sentinel while comparing it against `time.monotonic()`, whose epoch on Linux is host boot. On a host up for less than the 60-second throttle window, `now - 0.0` falls *inside* the window, so the throttle read boot as a just-emitted warning and swallowed the first one. A GitHub runner is seconds old; a laptop is not — hence green locally, red in CI.

The product behaviour was wrong in the case that matters most: a freshly started pod stayed silent about rejected auth attempts for its first minute of life, exactly when a misconfigured or hostile client is most likely to be hitting a new deployment. Fixed with a `None` sentinel so the first failure always warns.

Reproduced against the pre-fix code with `monotonic` pinned to `12.0`, giving the same two failures with the same assertions CI reported, then passing after the change. A regression test pins the 12-second-old-host case. No test was skipped or weakened.

## Third commit: italic regression, caught in review

The flanking rules above introduced a regression that the automated review found and I confirmed by execution. Every emphasis branch closed on a lookbehind requiring a non-space non-marker character, but the italic branch's alternation can consume a whole nested `**bold**` unit as its last element, and such a unit ends in `*`. An italic span whose final word is bold, with nothing between the two closers, stopped matching entirely:

```
input: *Remember, always **backup your data***
  pre-PR      ['*Remember, always **backup your data***']
  regressed   ['*Remember, always ', '**backup your data**', '*']   <- stray asterisks on the slide
  fixed       ['*Remember, always **backup your data***']
```

The sibling case in the tool description, `*italic with **bold** inside*`, survived only because the space before the closer satisfied the lookbehind, which is why the original tests missed it.

The right flank is now stated structurally on the italic branch: whatever is consumed last must itself be a valid flank, either a non-space non-star character or a complete nested bold unit. The other branches keep their lookbehind — none has a nested-unit alternative, and the single `*` their inner alternation can consume is by construction never adjacent to the closing marker.

Checked against the pre-PR regex across fifteen cases: identical output everywhere except the two the flanking rules were added to change. Backtracking was also measured rather than assumed — linear growth on the real `split()` path, within noise of the old pattern, 320KB of text in about 12ms.

## Tests

New `tests/test_pptx_robustness.py`, 37 tests that assert on the built presentation rather than on a file existing: cell coercion, unknown types, colour parsing, escape and flanking behaviour, nested emphasis, level coercion, chart type rejection, template slide removal via a fixture template built at runtime, and format-default agreement.

```
1020 passed, 6 deselected in 22.67s     # full suite, network excluded
All checks passed!                       # ruff
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYtbUgysFugzG2h8dhnKU1