### PR TITLE
feat(pptx)!: Phase 1 — typed slide schema, markdown bodies and a warnings channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ main.py                  ← Registers all MCP tools on a single FastMCP instanc
 
 1. Create `<type>_tools/` package with `__init__.py`, `base_<type>_tool.py`, and optional `helpers.py`.
 2. The base tool function should: accept content → produce an `io.BytesIO` → call `upload_file(buffer, "<ext>")` → return the result string.
+   - **Exception, deliberate:** `pptx_tools._create_presentation_buffer` returns `(BytesIO, warnings)`. The PowerPoint builder collects everything it had to work around (an image that would not load, body text shrunk to fit, a footer dropped because the layout has no placeholder) on `PowerpointPresentation.warnings`, and `main.py` returns those alongside the file so the model can correct its next call. Anything else that grows a warnings channel should follow the same shape.
 3. Register the async wrapper in `main.py` using `@mcp.tool(name=..., description=..., tags=..., annotations=...)`.
 4. Use `Annotated[<type>, Field(description=...)]` for all tool parameters — the descriptions are critical because MCP clients (AI models) rely on them.
 

--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ Just ask your AI to _"create a sales presentation"_ or _"draft a welcome email"_
 
 | Document Type | Tool | Highlights |
 |:---:|---|---|
-| 📊 **PowerPoint** | `create_powerpoint_presentation` | Title, section & content slides · 4:3 or 16:9 format · Custom templates · Author metadata, footer text & slide numbers · Inline markdown (**bold**, *italic*, ~~strikethrough~~, `code`) · Table column alignment |
+| 📊 **PowerPoint** | `create_powerpoint_presentation` | Typed slide schema (9 slide types) · Markdown bullet bodies · Tables, category charts & XY scatter · Inline & data-URI images · Theme colours · Autofit with overflow warnings · Proofing language · 4:3 or 16:9 · Custom templates |
 | 📝 **Word** | `create_word_from_markdown` | Write in Markdown, get a `.docx` · Headings, lists (with auto-restart), tables, links, images, block quotes, page breaks & text alignment · Superscript, subscript, underline & highlighted text · Table column alignment, borderless tables, proportional widths & multi-paragraph cells · Headers/footers with page numbers · Table of Contents · Custom style mapping & per-block style tags |
 | 📈 **Excel** | `create_excel_from_markdown` | Markdown tables → `.xlsx` · Multiple sheets · Formulas with table-relative & cross-sheet references · Column data types · Freeze panes & auto-filter · Column alignment |
 | 📧 **Email** | `create_email_draft` | HTML email drafts (`.eml`) · Subject, recipients, priority, language |
@@ -267,9 +267,76 @@ Set `RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED=false` only for local debugging or t
 
 ## 📝 Markdown Reference
 
-Both the Word and Excel tools accept Markdown. These references cover **everything** the parsers understand — including features that are easy to miss.
+The Word and Excel tools accept Markdown documents; the PowerPoint tool takes structured slides whose text fields accept Markdown. These references cover **everything** the parsers understand — including features that are easy to miss.
 
 > **Golden rule:** separate every block element (heading, list, table, quote…) with a **blank line**.
+
+<details>
+<summary><strong>📊 PowerPoint slides — full schema</strong></summary>
+
+**Tool parameters** (`create_powerpoint_presentation`):
+
+| Parameter | Description |
+|-----------|-------------|
+| `slides` | Ordered list of slide objects (below). Required. |
+| `format` | `16:9` (default) or `4:3`. |
+| `author` | Stored in document properties. |
+| `footer_text` | Shown on every slide whose layout has a footer placeholder. |
+| `show_slide_numbers` | Slide numbers on every slide. |
+| `language` | BCP-47 proofing tag, e.g. `cs-CZ`. Set it when the deck is not in the template's language, or Word/PowerPoint flags every word as misspelled. |
+| `file_name` | Output filename without extension. |
+
+Every slide takes `type` plus optional `title`, `notes` (speaker notes) and `layout`.
+
+| `type` | Fields |
+|--------|--------|
+| `title` | `subtitle?` |
+| `section` | — |
+| `content` | `body` |
+| `two_column` | `left`, `right` — each `{heading?, body}` |
+| `table` | `rows`, `align?`, `header_color?`, `zebra?`, `font_size?` |
+| `chart` | `chart_type`, `categories`, `series`, `legend?`, `data_labels?`, `number_format?`, `chart_title?`, `x_title?`, `y_title?` |
+| `scatter` | `series` (`{name, points: [[x, y], …]}`), `legend?`, `chart_title?`, `x_title?`, `y_title?` |
+| `image` | `source`, `caption?` |
+| `quote` | `text`, `attribution?` |
+
+**Body text.** `body` takes either a Markdown bullet string or explicit bullet objects. Prefer the string:
+
+```json
+{"type": "content", "title": "Q3 results",
+ "body": "- Revenue **up 12%**\n  - EMEA +18%\n  - APAC +4%\n- Churn flat"}
+```
+
+Indent child items with any consistent unit — two spaces, four spaces or a tab. A line without a `-` marker becomes a top-level bullet. The explicit form is `[{"text": "…", "level": 2}]`, where `level` is 1 (outermost) to 5.
+
+**Inline formatting** works in every text field: `**bold**`, `*italic*`, `***bold italic***`, `~~strikethrough~~`, `__underline__`, `` `code` ``. A marker only formats when it hugs its text (`**bold**`, not `** bold **`), so prose like `5 * 3 * 2 = 30` is left alone. Escape a literal marker with `\*`, or wrap it in backticks.
+
+**Tables** take raw values — numbers and `null` are fine, not just strings:
+
+```json
+{"type": "table", "title": "Pricing",
+ "rows": [["Plan", "Users", "Price"], ["Basic", 5, 9.0], ["Pro", 25, 29.0]],
+ "align": ["left", "right", "right"], "header_color": "accent1"}
+```
+
+**Colours** accept 6-digit hex with or without `#`, or a theme name (`accent1`…`accent6`, `dark1`, `dark2`, `light1`, `light2`). Prefer a theme name so the deck follows your template's palette.
+
+**Images** take an https URL or an inline data URI, so an image you already hold can be placed without publishing it first:
+
+```json
+{"type": "image", "source": "data:image/png;base64,iVBORw0KGgo…", "caption": "Fig 1"}
+```
+
+**Warnings.** When the deck is produced but not exactly as asked — an image that would not load, body text shrunk to fit, a footer dropped because the layout has no placeholder — the result carries a `warnings` list alongside the file instead of leaving it in the server log:
+
+```json
+{"file": "https://…/deck.pptx", "slide_count": 12,
+ "warnings": ["slide 4: body text is about 1.9x the space available and will be shrunk to fit; consider splitting it across slides."]}
+```
+
+**Compatibility.** The previous key names (`slide_type`, `slide_title`, `slide_text`, `indentation_level`, `speaker_notes`, `table_data`, `alternate_rows`, `image_url`, `image_caption`, `quote_text`, `quote_author`, `left_column`, `right_column`, `chart_data`, `has_legend`, `legend_position`) are still accepted and mapped onto the current ones, with a note in the log. They will be removed in a future release.
+
+</details>
 
 <details>
 <summary><strong>📝 Word Markdown — full syntax</strong></summary>

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from pydantic import Field
 from xlsx_tools import _markdown_to_excel_buffer
 from docx_tools import _markdown_to_word_buffer
 from docx_tools.dynamic_docx_tools import register_docx_template_tools_from_yaml
-from pptx_tools import _create_presentation_buffer
+from pptx_tools import _create_presentation_buffer, Slides
 from email_tools import _create_eml_buffer
 from email_tools.dynamic_email_tools import register_email_template_tools_from_yaml
 from pathlib import Path
@@ -293,21 +293,32 @@ async def create_word_document(
     annotations={"title": "PowerPoint Presentation Creator"}
 )
 async def create_powerpoint_presentation(
-    slides: Annotated[List[dict], Field(
-        description="""List of slide objects. Each slide requires 'slide_type' (str) and type-specific fields:
-
-- title: {slide_type: "title", slide_title: str, subtitle?: str}  (subtitle can contain author name, tagline, date, etc.)
-- section: {slide_type: "section", slide_title: str}
-- content: {slide_type: "content", slide_title: str, slide_text: [{text: str, indentation_level: int (1-3)}]}
-- table: {slide_type: "table", slide_title: str, table_data: [[str|number|null]] (first row = header; optional second row with :---|:---:|---: for left/center/right column alignment), header_color?: str (6-digit hex, with or without '#'), alternate_rows?: bool}
-- image: {slide_type: "image", slide_title?: str, image_url: str, image_caption?: str}
-- two_column: {slide_type: "two_column", slide_title: str, left_column: [{text: str, indentation_level: int}], right_column: [{text: str, indentation_level: int}], left_heading?: str, right_heading?: str}
-- chart: {slide_type: "chart", slide_title: str, chart_type: str (bar|bar_stacked|column|column_stacked|line|line_markers|pie|doughnut|area|area_stacked|radar), chart_data: {categories: [str], series: [{name: str, values: [number]}]}, has_legend?: bool, legend_position?: str}
-- quote: {slide_type: "quote", slide_title?: str, quote_text: str, quote_author?: str}
-
-All slides support optional 'speaker_notes': str field. An unrecognised slide_type is rejected with an error listing the valid types — it is never skipped silently.
-
-Inline markdown formatting is supported in text fields (slide_text, quote_text, left_column, right_column): **bold**, *italic*, ***bold italic***, ~~strikethrough~~, __underline__, `code`. A marker only formats when it hugs its text (**bold**, not ** bold **), so ordinary prose such as "5 * 3 * 2" is left alone. Escape a literal marker with a backslash (\\*), or wrap it in backticks to render it verbatim."""
+    slides: Annotated[Slides, Field(
+        description=(
+            "Ordered list of slides. Each slide's 'type' selects its shape; the schema for "
+            "every type is given above, so only the rules it cannot express are repeated here.\n"
+            "\n"
+            "BODY TEXT ('body' on content slides and on each side of two_column): either a markdown "
+            "bullet string or explicit bullet objects. Prefer the string — write '- item' per line and "
+            "indent child items to nest them (any consistent unit: 2 spaces, 4 spaces or a tab). "
+            "A line with no '-' marker becomes a top-level bullet.\n"
+            "\n"
+            "INLINE MARKDOWN in any text field: **bold**, *italic*, ***bold italic***, ~~strikethrough~~, "
+            "__underline__, `code`. A marker formats only when it hugs its text (**bold**, not ** bold **), "
+            "so prose such as '5 * 3 * 2' is left alone. Escape a literal marker with a backslash (\\*) or "
+            "wrap it in backticks.\n"
+            "\n"
+            "COLOURS: 6-digit hex with or without '#', or a theme name (accent1..accent6, dark1, dark2, "
+            "light1, light2). Prefer a theme name so the deck follows the template's palette.\n"
+            "\n"
+            "IMAGES: 'source' takes an https URL or an inline data URI (data:image/png;base64,...).\n"
+            "\n"
+            "CHARTS: use the 'chart' type for category charts and the 'scatter' type for XY data "
+            "([x, y] point pairs). Keep each series' 'values' the same length as 'categories'.\n"
+            "\n"
+            "Text that overflows its slide is shrunk to fit and reported in the result's 'warnings'; "
+            "split the content across slides rather than relying on that."
+        )
     )],
     format: Annotated[Literal["4:3", "16:9"], Field(
         default="16:9",
@@ -316,28 +327,32 @@ Inline markdown formatting is supported in text fields (slide_text, quote_text, 
     author: Annotated[Optional[str], Field(description="Author name stored in document properties/metadata.", default=None)] = None,
     footer_text: Annotated[Optional[str], Field(description="Footer text displayed on every slide (e.g., company name, confidentiality notice).", default=None)] = None,
     show_slide_numbers: Annotated[bool, Field(description="Show slide numbers on every slide.", default=False)] = False,
+    language: Annotated[Optional[str], Field(description="Language tag for proofing in PowerPoint (e.g. 'cs-CZ' for Czech, 'en-US' for English, 'de-DE' for German). Set this when the deck is not in the template's own language, otherwise every word is flagged as a misspelling.", default=None)] = None,
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
     add_unique_prefix: Annotated[Optional[bool], Field(description="If true, adds 8-char UUID prefix to filename for uniqueness. If not set, defaults to True for traditional storage backends (LOCAL/S3/GCS/AZURE/MINIO) and False for LibreChat.", default=None)] = None,
 ) -> Union[str, dict]:
     """Creates PowerPoint presentations with structured slide models and professional templates.
 
     Returns:
-        For traditional upload strategies: URL string
-        For LIBRECHAT strategy: MCP file artifact dict
+        For traditional upload strategies: a dict with the file location,
+        slide_count and any warnings (a bare URL string when there is nothing
+        to report, preserving the previous response shape).
+        For LIBRECHAT strategy: MCP file artifact dict.
     """
 
     logger.info(f"Creating PowerPoint presentation with {len(slides)} slides in {format} format")
 
     try:
         # Generate presentation buffer
-        file_buffer = await run_blocking(
+        file_buffer, warnings = await run_blocking(
             _create_presentation_buffer,
             slides, format,
             author=author,
             footer_text=footer_text,
             show_slide_numbers=show_slide_numbers,
+            language=language,
         )
-        
+
         # Upload and format response (handles both LIBRECHAT and traditional backends)
         user_context = extract_user_context_from_request()
         result = await upload_and_format_response(
@@ -349,9 +364,26 @@ Inline markdown formatting is supported in text fields (slide_text, quote_text, 
             add_unique_prefix=add_unique_prefix,
         )
         file_buffer.close()
-        
+
         logger.info("PowerPoint presentation created successfully")
+
+        # Warnings describe a deck that was produced but not exactly as asked
+        # (an image that would not load, text shrunk to fit, a dropped footer).
+        # They ride alongside the result so the model can correct its next call
+        # instead of the problem living only in the server log.
+        if warnings and isinstance(result, str):
+            return {
+                "file": result,
+                "slide_count": len(slides),
+                "warnings": warnings,
+            }
+        if warnings and isinstance(result, dict):
+            result = {**result, "warnings": warnings}
         return result
+    except ValueError as e:
+        # Schema/validation problems: the message names the slide and field.
+        logger.error(f"Invalid presentation input: {e}")
+        raise ToolError(str(e))
     except Exception as e:
         logger.error(f"Error creating PowerPoint presentation: {e}", exc_info=True)
         raise ToolError(f"Error creating PowerPoint presentation: {e}")

--- a/pptx_tools/__init__.py
+++ b/pptx_tools/__init__.py
@@ -1,19 +1,31 @@
 from .base_pptx_tool import create_presentation, _create_presentation_buffer
 from .slide_builder import PowerpointPresentation
-from .image_utils import download_image, ImageDownloadError, ImageValidationError
-from .chart_utils import (
-    add_chart_to_slide, CHART_TYPE_MAP, UNSUPPORTED_CHART_TYPES, ChartDataError,
+from .image_utils import (
+    download_image, load_image, decode_data_uri,
+    ImageDownloadError, ImageValidationError,
 )
+from .chart_utils import (
+    add_chart_to_slide, add_scatter_to_slide,
+    CHART_TYPE_MAP, UNSUPPORTED_CHART_TYPES, ChartDataError,
+)
+from .schema import AnySlide, Slides, SLIDE_TYPES, coerce_slides
 
 __all__ = [
     "create_presentation",
     "_create_presentation_buffer",
     "PowerpointPresentation",
     "download_image",
+    "load_image",
+    "decode_data_uri",
     "ImageDownloadError",
     "ImageValidationError",
     "add_chart_to_slide",
+    "add_scatter_to_slide",
     "CHART_TYPE_MAP",
     "UNSUPPORTED_CHART_TYPES",
     "ChartDataError",
+    "AnySlide",
+    "Slides",
+    "SLIDE_TYPES",
+    "coerce_slides",
 ]

--- a/pptx_tools/base_pptx_tool.py
+++ b/pptx_tools/base_pptx_tool.py
@@ -1,6 +1,6 @@
 import io
 import logging
-from typing import List, Dict, Any, Optional
+from typing import Any, List, Optional, Sequence, Tuple
 
 from upload_tools import upload_file
 from .constants import DEFAULT_SLIDE_FORMAT
@@ -10,23 +10,27 @@ logger = logging.getLogger(__name__)
 
 
 def _create_presentation_buffer(
-    slides: List[Dict[str, Any]],
+    slides: Sequence[Any],
     format: str = DEFAULT_SLIDE_FORMAT,
     author: Optional[str] = None,
     footer_text: Optional[str] = None,
     show_slide_numbers: bool = False,
-) -> io.BytesIO:
-    """Create a PowerPoint presentation and return as BytesIO buffer.
+    language: Optional[str] = None,
+) -> Tuple[io.BytesIO, List[str]]:
+    """Create a PowerPoint presentation and return its bytes and any warnings.
 
     This function is useful when the caller needs to handle upload separately,
     such as for LibreChat file artifact uploads.
 
-    :param slides: List of slide dicts with keys based on slide_type
+    :param slides: Slide models, or dicts in the current or previous spelling
     :param format: "4:3" or "16:9" (defaults to the shared DEFAULT_SLIDE_FORMAT)
     :param author: Author name for document properties
     :param footer_text: Optional footer text displayed on all slides
     :param show_slide_numbers: Whether to show slide numbers
-    :return: BytesIO buffer containing the PowerPoint file (position at start)
+    :param language: BCP-47 tag stamped on every run for proofing
+    :return: ``(buffer, warnings)`` — the buffer is positioned at the start,
+        and warnings describe anything the builder had to work around so the
+        caller can act on it instead of only seeing it in the server log.
     """
     if not slides:
         raise ValueError("No slides provided")
@@ -38,33 +42,37 @@ def _create_presentation_buffer(
         author=author,
         footer_text=footer_text,
         show_slide_numbers=show_slide_numbers,
+        language=language,
     )
-    return presentation.save()
+    return presentation.save(), presentation.warnings
 
 
 def create_presentation(
-    slides: List[Dict[str, Any]],
+    slides: Sequence[Any],
     format: str = DEFAULT_SLIDE_FORMAT,
     file_name: Optional[str] = None,
     author: Optional[str] = None,
     footer_text: Optional[str] = None,
     show_slide_numbers: bool = False,
+    language: Optional[str] = None,
 ) -> str:
     """Create a PowerPoint presentation from structured slides and upload it.
 
-    :param slides: List of slide dicts with keys based on slide_type
+    :param slides: Slide models, or dicts in the current or previous spelling
     :param format: "4:3" or "16:9"
     :param file_name: Optional custom filename (without extension)
     :param author: Author name for document properties
     :param footer_text: Optional footer text displayed on all slides
     :param show_slide_numbers: Whether to show slide numbers
+    :param language: BCP-47 tag stamped on every run for proofing
     :return: Upload status or URL text
     """
-    file_object = _create_presentation_buffer(
+    file_object, warnings = _create_presentation_buffer(
         slides, format,
         author=author,
         footer_text=footer_text,
         show_slide_numbers=show_slide_numbers,
+        language=language,
     )
 
     try:
@@ -72,6 +80,8 @@ def create_presentation(
     finally:
         file_object.close()
 
+    if warnings:
+        logger.info("Presentation created with %d warning(s)", len(warnings))
+
     logger.info("PowerPoint upload completed")
     return text
-

--- a/pptx_tools/chart_utils.py
+++ b/pptx_tools/chart_utils.py
@@ -244,6 +244,20 @@ def set_axis_titles(chart, x_title: Optional[str] = None, y_title: Optional[str]
             logger.debug("Chart type has no %s; skipping its title", axis_name)
 
 
+def _series_field(entry, field: str):
+    """Read *field* from a model attribute or a mapping key.
+
+    Written out rather than expressed as ``getattr(...) or entry.get(...)``:
+    that idiom cannot tell "absent" from "present but falsy", so a legal
+    empty-string series name resolved to None. It is a narrow case — the
+    rendered legend entry came out the same either way — but it is the kind of
+    thing duck typing hides until it matters.
+    """
+    if isinstance(entry, dict):
+        return entry.get(field)
+    return getattr(entry, field, None)
+
+
 def add_scatter_to_slide(
     slide,
     series: list,
@@ -270,11 +284,12 @@ def add_scatter_to_slide(
         raise ChartDataError("Scatter chart needs at least one series")
 
     data = XyChartData()
-    for entry in series:
-        name = getattr(entry, "name", None) or (entry.get("name") if isinstance(entry, dict) else None)
-        points = getattr(entry, "points", None)
-        if points is None and isinstance(entry, dict):
-            points = entry.get("points")
+    for i, entry in enumerate(series):
+        name = _series_field(entry, "name")
+        points = _series_field(entry, "points")
+
+        if name is None:
+            raise ChartDataError(f"Scatter series {i} has no name")
         if not points:
             raise ChartDataError(f"Scatter series {name!r} has no points")
 

--- a/pptx_tools/chart_utils.py
+++ b/pptx_tools/chart_utils.py
@@ -7,8 +7,9 @@ using python-pptx's chart capabilities.
 import logging
 from typing import Dict, Any, Optional
 
-from pptx.chart.data import CategoryChartData
-from pptx.enum.chart import XL_CHART_TYPE, XL_LEGEND_POSITION
+from pptx.chart.data import CategoryChartData, XyChartData
+from pptx.enum.chart import XL_CHART_TYPE, XL_LEGEND_POSITION, XL_LABEL_POSITION
+from pptx.util import Pt
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +36,22 @@ CHART_TYPE_MAP = {
     'radar': XL_CHART_TYPE.RADAR,
 }
 
-# Chart types that are recognised but not supported, mapped to the advice shown
-# to the caller. Without this, 'scatter' would report only "Unknown chart type".
+# Scatter is an XY chart: it needs XyChartData and (x, y) pairs rather than
+# categories, so it is built by add_scatter_to_slide() and deliberately absent
+# from CHART_TYPE_MAP. Asking for it as a category chart_type is still a
+# mistake worth naming precisely.
 UNSUPPORTED_CHART_TYPES = {
     'scatter': (
-        "Scatter (XY) charts are not supported yet because they need (x, y) point "
-        "pairs rather than categories and series. Use 'line_markers' for a trend "
-        "over ordered categories."
+        "Scatter is its own slide type, not a category chart_type: use "
+        "{\"type\": \"scatter\", \"series\": [{\"name\": ..., \"points\": [[x, y], ...]}]}."
     ),
+}
+
+LEGEND_POSITIONS = {
+    'left': XL_LEGEND_POSITION.LEFT,
+    'right': XL_LEGEND_POSITION.RIGHT,
+    'top': XL_LEGEND_POSITION.TOP,
+    'bottom': XL_LEGEND_POSITION.BOTTOM,
 }
 
 
@@ -158,27 +167,131 @@ def add_chart_to_slide(
 
     chart = chart_shape.chart
 
-    # Configure legend
-    if has_legend:
-        chart.has_legend = True
-        legend_positions = {
-            'left': XL_LEGEND_POSITION.LEFT,
-            'right': XL_LEGEND_POSITION.RIGHT,
-            'top': XL_LEGEND_POSITION.TOP,
-            'bottom': XL_LEGEND_POSITION.BOTTOM,
-        }
-        chart.legend.position = legend_positions.get(legend_position, XL_LEGEND_POSITION.RIGHT)
-        chart.legend.include_in_layout = False
-    else:
-        chart.has_legend = False
+    _configure_legend(chart, has_legend, legend_position)
+    _configure_title(chart, title)
 
-    # Set chart title if provided
+    logger.debug(f"Chart added successfully with {len(chart_data['series'])} series")
+    return chart
+
+
+# ---------------------------------------------------------------------------
+# Shared chart configuration
+# ---------------------------------------------------------------------------
+
+def _configure_legend(chart, has_legend: bool, legend_position: str) -> None:
+    """Show or hide the legend and place it."""
+    if not has_legend or legend_position == 'none':
+        chart.has_legend = False
+        return
+    chart.has_legend = True
+    chart.legend.position = LEGEND_POSITIONS.get(legend_position, XL_LEGEND_POSITION.RIGHT)
+    chart.legend.include_in_layout = False
+
+
+def _configure_title(chart, title: Optional[str]) -> None:
+    """Set or clear the chart's own title."""
     if title:
         chart.has_title = True
         chart.chart_title.text_frame.paragraphs[0].text = title
     else:
         chart.has_title = False
 
-    logger.debug(f"Chart added successfully with {len(chart_data['series'])} series")
+
+def configure_data_labels(chart, enabled: bool, number_format: Optional[str] = None) -> None:
+    """Turn value labels on each point on or off.
+
+    A number format without labels is still applied to the value axis, so
+    "#,##0" or "0.0%" formats the tick labels even when the caller did not ask
+    for per-point labels.
+    """
+    plot = chart.plots[0]
+    plot.has_data_labels = bool(enabled)
+    if enabled:
+        labels = plot.data_labels
+        labels.font.size = Pt(10)
+        if number_format:
+            labels.number_format = number_format
+            labels.number_format_is_linked = False
+        try:
+            labels.position = XL_LABEL_POSITION.OUTSIDE_END
+        except (ValueError, NotImplementedError):
+            # Not valid for every chart type (pie/doughnut/stacked); the
+            # default position is fine there.
+            pass
+    elif number_format:
+        try:
+            chart.value_axis.tick_labels.number_format = number_format
+            chart.value_axis.tick_labels.number_format_is_linked = False
+        except (ValueError, NotImplementedError):
+            pass
+
+
+def set_axis_titles(chart, x_title: Optional[str] = None, y_title: Optional[str] = None) -> None:
+    """Label the category and value axes, where the chart type has them.
+
+    Pie and doughnut charts have no axes; asking for a title there is a no-op
+    rather than an error, because it is a reasonable thing for a caller to send
+    without knowing the chart type's geometry.
+    """
+    for axis_name, title in (("category_axis", x_title), ("value_axis", y_title)):
+        if not title:
+            continue
+        try:
+            axis = getattr(chart, axis_name)
+            axis.has_title = True
+            axis.axis_title.text_frame.paragraphs[0].text = title
+        except (ValueError, NotImplementedError, AttributeError):
+            logger.debug("Chart type has no %s; skipping its title", axis_name)
+
+
+def add_scatter_to_slide(
+    slide,
+    series: list,
+    left: int,
+    top: int,
+    width: int,
+    height: int,
+    legend: str = 'right',
+    title: Optional[str] = None,
+    x_title: Optional[str] = None,
+    y_title: Optional[str] = None,
+):
+    """Add an XY (scatter) chart built from [x, y] point pairs.
+
+    Separate from :func:`add_chart_to_slide` because an XY chart needs
+    ``XyChartData``: feeding categories and series to it raises
+    ``'CategoryWorkbookWriter' object has no attribute 'x_values_ref'``, which
+    is why the previously advertised 'scatter' chart_type could never build.
+
+    Args:
+        series: Objects with ``name`` and ``points`` ([[x, y], ...]).
+    """
+    if not series:
+        raise ChartDataError("Scatter chart needs at least one series")
+
+    data = XyChartData()
+    for entry in series:
+        name = getattr(entry, "name", None) or (entry.get("name") if isinstance(entry, dict) else None)
+        points = getattr(entry, "points", None)
+        if points is None and isinstance(entry, dict):
+            points = entry.get("points")
+        if not points:
+            raise ChartDataError(f"Scatter series {name!r} has no points")
+
+        series_data = data.add_series(name)
+        for x, y in points:
+            series_data.add_data_point(float(x), float(y))
+
+    chart_shape = slide.shapes.add_chart(
+        XL_CHART_TYPE.XY_SCATTER, left, top, width, height, data
+    )
+    chart = chart_shape.chart
+
+    _configure_legend(chart, legend != 'none', legend)
+    _configure_title(chart, title)
+    set_axis_titles(chart, x_title, y_title)
+
+    logger.debug("Scatter chart added with %d series", len(series))
+    return chart
 
 

--- a/pptx_tools/constants.py
+++ b/pptx_tools/constants.py
@@ -56,6 +56,30 @@ MAX_INDENT_LEVEL = 5
 
 
 # =============================================================================
+# Autofit / overflow estimation
+# =============================================================================
+# Text is measured by estimate, not by a font engine: python-pptx cannot lay
+# text out, and shipping a font metrics dependency for a warning is not worth
+# it. The numbers below are deliberately rough and only drive (a) a shrink
+# factor written into <a:normAutofit>, which PowerPoint recomputes exactly when
+# the deck is opened, and (b) a warning returned to the caller.
+
+# Mean glyph advance as a fraction of the font size, for a mixed-case latin
+# sentence in the template's body face.
+AVG_CHAR_WIDTH_RATIO = 0.5
+# Baseline-to-baseline distance as a multiple of the font size.
+LINE_HEIGHT_RATIO = 1.22
+# Never shrink text below this fraction of its nominal size; past here the
+# slide is genuinely overfull and the caller should split it.
+MIN_AUTOFIT_SCALE = 0.6
+
+# Tables get shrunk by row count rather than by text metrics.
+TABLE_MIN_FONT_SIZE = 9
+# Rough row height (in points) per point of font size, including cell padding.
+TABLE_ROW_HEIGHT_PER_POINT = 2.1
+
+
+# =============================================================================
 # Table Colors
 # =============================================================================
 

--- a/pptx_tools/helpers.py
+++ b/pptx_tools/helpers.py
@@ -6,21 +6,26 @@ functions for template loading and data parsing.
 """
 
 import logging
+import math
 import re
 from typing import List, Tuple, Optional, Any
 
 from pptx.enum.text import PP_ALIGN
-from pptx.util import Inches
+from pptx.util import Emu, Inches, Pt
 from pptx.dml.color import RGBColor
 from pptx.oxml import parse_xml
+from pptx.oxml.ns import qn
 
 from .constants import (
     CONTENT_LAYOUT,
     DEFAULT_BODY_FONT_SIZE,
     MARGIN_LEFT, MAX_INDENT_LEVEL,
+    AVG_CHAR_WIDTH_RATIO, LINE_HEIGHT_RATIO, MIN_AUTOFIT_SCALE,
+    TABLE_MIN_FONT_SIZE, TABLE_ROW_HEIGHT_PER_POINT,
     TABLE_HEADER_FILL, TABLE_HEADER_TEXT, TABLE_ALT_ROW_FILL,
 )
-from .image_utils import download_image, ImageDownloadError, ImageValidationError
+from .schema import Bullet, THEME_COLORS
+from .image_utils import load_image, ImageDownloadError, ImageValidationError
 from .inline_formatting import needs_inline_processing, apply_inline_formatting
 
 logger = logging.getLogger(__name__)
@@ -140,6 +145,173 @@ def parse_color(color_hex: Any, default: RGBColor) -> RGBColor:
             color_hex, default,
         )
         return default
+
+
+_BULLET_LINE_RE = re.compile(r'^(\s*)[-*+]\s+(.*)$')
+
+
+def body_to_bullets(body: Any) -> List[Bullet]:
+    """Normalise a slide ``body`` into a list of :class:`Bullet`.
+
+    Accepts what the schema allows: a markdown bullet string, or explicit
+    bullet objects. In the string form, nesting comes from indentation and the
+    unit is inferred rather than fixed — the distinct indent widths present are
+    sorted and mapped onto levels 1, 2, 3…, so two-space, four-space and tab
+    indentation all work without the caller declaring which they used. A line
+    with no bullet marker is treated as a top-level bullet.
+    """
+    if body is None:
+        return []
+
+    if isinstance(body, list):
+        out: List[Bullet] = []
+        for item in body:
+            if isinstance(item, Bullet):
+                out.append(item)
+            elif isinstance(item, dict):
+                out.append(Bullet(**item))
+            else:
+                out.append(Bullet(text=cell_to_text(item)))
+        return out
+
+    if not isinstance(body, str):
+        return [Bullet(text=cell_to_text(body))]
+
+    parsed: List[Tuple[int, str]] = []
+    for line in body.splitlines():
+        if not line.strip():
+            continue
+        match = _BULLET_LINE_RE.match(line)
+        if match:
+            indent = len(match.group(1).replace('\t', '    '))
+            text = match.group(2).strip()
+        else:
+            indent = 0
+            text = line.strip()
+        if text:
+            parsed.append((indent, text))
+
+    if not parsed:
+        return []
+
+    # Map the distinct indent widths onto consecutive levels.
+    widths = sorted({indent for indent, _ in parsed})
+    level_of = {width: min(rank + 1, MAX_INDENT_LEVEL) for rank, width in enumerate(widths)}
+
+    return [Bullet(text=text, level=level_of[indent]) for indent, text in parsed]
+
+
+def estimate_text_fill(
+    bullets: List[Bullet],
+    width: int,
+    height: int,
+    font_size_pt: float = 18.0,
+) -> float:
+    """Estimate how full a text box will be, as a ratio (1.0 = exactly full).
+
+    Deliberately approximate — see the constants module. Used to decide whether
+    to ask PowerPoint to shrink the text and whether to warn the caller.
+    """
+    width_in = Emu(width).inches
+    height_in = Emu(height).inches
+    if width_in <= 0 or height_in <= 0 or not bullets:
+        return 0.0
+
+    char_width_in = AVG_CHAR_WIDTH_RATIO * font_size_pt / 72.0
+    line_height_in = LINE_HEIGHT_RATIO * font_size_pt / 72.0
+
+    total_lines = 0
+    for bullet in bullets:
+        # Deeper levels are indented, so less width is available for text.
+        indent_in = 0.3 * (bullet.level - 1)
+        usable_in = max(width_in - indent_in, char_width_in)
+        chars_per_line = max(int(usable_in / char_width_in), 1)
+        total_lines += max(1, math.ceil(len(bullet.text) / chars_per_line))
+
+    return (total_lines * line_height_in) / height_in
+
+
+def apply_autofit(text_frame, scale: Optional[float] = None) -> None:
+    """Mark a text frame as shrink-to-fit, optionally pinning the shrink factor.
+
+    ``<a:normAutofit/>`` alone tells PowerPoint to shrink the text, but it
+    recomputes the factor only when the deck is opened for editing; some
+    viewers render the text at full size and overflowing until then. Writing an
+    explicit ``fontScale`` gives those viewers something to honour immediately,
+    and PowerPoint overwrites it with its own exact value on the first edit.
+    """
+    bodyPr = text_frame._txBody.find(qn('a:bodyPr'))
+    if bodyPr is None:
+        return
+
+    for tag in ('a:noAutofit', 'a:spAutoFit', 'a:normAutofit'):
+        existing = bodyPr.find(qn(tag))
+        if existing is not None:
+            bodyPr.remove(existing)
+
+    autofit = parse_xml(
+        '<a:normAutofit xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"/>'
+    )
+    if scale is not None and scale < 1.0:
+        percent = max(scale, MIN_AUTOFIT_SCALE)
+        autofit.set('fontScale', str(int(percent * 100000)))
+        autofit.set('lnSpcReduction', '10000')
+    bodyPr.append(autofit)
+
+
+def set_runs_language(shape_or_frame, language: str) -> None:
+    """Stamp ``lang`` on every run of a text frame.
+
+    Without this the runs inherit the template's language, so a Czech deck is
+    proof-read against the template's locale and every word is underlined as a
+    misspelling.
+    """
+    text_frame = getattr(shape_or_frame, "text_frame", shape_or_frame)
+    try:
+        paragraphs = text_frame.paragraphs
+    except AttributeError:
+        return
+
+    for paragraph in paragraphs:
+        for run in paragraph.runs:
+            run._r.get_or_add_rPr().set('lang', language)
+        endParaRPr = paragraph._p.find(qn('a:endParaRPr'))
+        if endParaRPr is not None:
+            endParaRPr.set('lang', language)
+
+
+def fit_table_font_size(row_count: int, height: int) -> int:
+    """Pick a cell font size that keeps *row_count* rows inside *height*.
+
+    PowerPoint grows a table to fit its text, so a tall table silently runs off
+    the bottom of the slide rather than shrinking. Choosing the size up front
+    from the row budget is what keeps a 20-row table on the slide.
+    """
+    height_pt = max(Emu(height).inches * 72.0, 1.0)
+    per_row_pt = height_pt / max(row_count, 1)
+    size = int(per_row_pt / TABLE_ROW_HEIGHT_PER_POINT)
+    return max(TABLE_MIN_FONT_SIZE, min(size, int(DEFAULT_BODY_FONT_SIZE.pt)))
+
+
+def table_overflows(row_count: int, height: int, font_size_pt: int) -> bool:
+    """True when the table still cannot fit even at *font_size_pt*."""
+    needed_pt = row_count * font_size_pt * TABLE_ROW_HEIGHT_PER_POINT
+    return needed_pt > Emu(height).inches * 72.0
+
+
+def resolve_fill(color: Optional[str], default: RGBColor):
+    """Return either an ``RGBColor`` or a theme colour name for *color*.
+
+    The schema accepts both ``#RRGGBB`` and a theme name such as ``accent1``;
+    they need different DrawingML (``srgbClr`` vs ``schemeClr``), so the caller
+    is told which it got.
+    """
+    if color is None:
+        return default
+    text = str(color).strip()
+    if text.lower() in THEME_COLORS:
+        return text.lower()
+    return parse_color(text, default)
 
 
 def coerce_indent_level(value: Any) -> int:
@@ -301,50 +473,54 @@ class SlideHelpers:
         **bold**, *italic*, ***bold italic***, ~~strikethrough~~,
         __underline__, `code`.
 
-        A bullet may also be given as a bare string, which is treated as
-        ``{"text": <string>}`` at the top level.
+        Accepts anything :func:`body_to_bullets` understands: a markdown
+        string, explicit :class:`Bullet` objects, dicts, or bare strings.
 
         Args:
             text_frame: PowerPoint text frame object (from placeholder or textbox).
-            items: List of dicts with 'text' and 'indentation_level' keys.
+            items: Slide body — markdown string or bullet objects.
             font_size: Optional font size for items.
+
+        Returns:
+            The bullets actually rendered, so the caller can measure them.
         """
-        if not items:
-            return
+        bullets = body_to_bullets(items)
+        if not bullets:
+            return []
 
         text_frame.word_wrap = True
 
-        for i, item in enumerate(items):
-            if not isinstance(item, dict):
-                item = {"text": cell_to_text(item)}
-
+        for i, bullet in enumerate(bullets):
             if i == 0:
                 para = text_frame.paragraphs[0]
             else:
                 para = text_frame.add_paragraph()
 
-            item_text = cell_to_text(item.get("text", ""))
             para.alignment = PP_ALIGN.LEFT
-            para.level = coerce_indent_level(item.get("indentation_level", 1))
+            para.level = max(0, min(bullet.level, MAX_INDENT_LEVEL) - 1)
 
             # Apply inline markdown formatting when markers OR escapes are present
-            if needs_inline_processing(item_text):
-                apply_inline_formatting(para, item_text, font_size=font_size)
+            if needs_inline_processing(bullet.text):
+                apply_inline_formatting(para, bullet.text, font_size=font_size)
             else:
-                para.text = item_text
+                para.text = bullet.text
                 if font_size:
                     para.font.size = font_size
+
+        return bullets
 
     # -------------------------------------------------------------------------
     # Table Helpers
     # -------------------------------------------------------------------------
 
-    def _set_cell_fill(self, cell, color: RGBColor) -> None:
+    def _set_cell_fill(self, cell, color) -> None:
         """Set the background fill color of a table cell.
 
         Args:
             cell: Table cell object.
-            color: RGBColor for the fill.
+            color: An ``RGBColor``, or a theme colour name such as "accent1".
+                A theme name is written as ``schemeClr`` so the fill follows
+                the template's palette instead of being pinned to a literal.
         """
         try:
             tc = cell._tc
@@ -355,13 +531,13 @@ class SlideHelpers:
                 if child.tag.endswith('}solidFill'):
                     tcPr.remove(child)
 
-            # Add new fill
-            solidFill = parse_xml(
-                f'<a:solidFill xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">'
-                f'<a:srgbClr val="{color}"/>'
-                f'</a:solidFill>'
-            )
-            tcPr.append(solidFill)
+            ns = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+            if isinstance(color, str):
+                inner = f'<a:schemeClr val="{color}"/>'
+            else:
+                inner = f'<a:srgbClr val="{color}"/>'
+
+            tcPr.append(parse_xml(f'<a:solidFill {ns}>{inner}</a:solidFill>'))
         except Exception as e:
             logger.debug(f"Could not set cell fill color: {e}")
 
@@ -373,9 +549,10 @@ class SlideHelpers:
         top: int,
         width: int,
         height: int,
-        header_color: Optional[RGBColor] = None,
+        header_color=None,
         alternate_rows: bool = True,
-        column_alignments: Optional[List] = None
+        column_alignments: Optional[List] = None,
+        font_size: Optional[int] = None,
     ):
         """Create a styled table on a slide.
 
@@ -383,24 +560,28 @@ class SlideHelpers:
             slide: PowerPoint slide object.
             table_data: List of rows (first row is header).
             left, top, width, height: Position and size.
-            header_color: Header background color.
+            header_color: Header background colour (RGBColor or theme name).
             alternate_rows: Whether to use alternating row colors.
             column_alignments: Optional list of PP_ALIGN values per column
                 (extracted from markdown separator row).
+            font_size: Explicit cell font size in points. When omitted, the
+                size is chosen from the row count so a tall table still fits
+                the content area instead of running off the slide.
 
         Returns:
-            Created table shape.
+            Tuple of (table shape, chosen font size in points or None).
         """
         num_rows = len(table_data)
         num_cols = max((len(row) for row in table_data), default=0)
 
         if num_rows == 0 or num_cols == 0:
-            return None
+            return None, None
 
         shape = slide.shapes.add_table(num_rows, num_cols, left, top, width, height)
         table = shape.table
 
-        header_color = header_color or TABLE_HEADER_FILL
+        header_color = header_color if header_color is not None else TABLE_HEADER_FILL
+        points = font_size or fit_table_font_size(num_rows, height)
 
         for row_idx, row_data in enumerate(table_data):
             for col_idx, cell_text in enumerate(row_data):
@@ -411,56 +592,62 @@ class SlideHelpers:
                 # cell_to_text, not a falsy test: `if cell_text` blanked a numeric 0.
                 cell.text = cell_to_text(cell_text)
 
+                paragraph = cell.text_frame.paragraphs[0]
+
                 # Apply column alignment
                 if column_alignments and col_idx < len(column_alignments):
                     alignment = column_alignments[col_idx]
                     if alignment is not None:
-                        cell.text_frame.paragraphs[0].alignment = alignment
+                        paragraph.alignment = alignment
+
+                if points:
+                    paragraph.font.size = Pt(points)
 
                 if row_idx == 0:  # Header row
-                    cell.text_frame.paragraphs[0].font.bold = True
-                    cell.text_frame.paragraphs[0].font.color.rgb = TABLE_HEADER_TEXT
+                    paragraph.font.bold = True
+                    paragraph.font.color.rgb = TABLE_HEADER_TEXT
                     self._set_cell_fill(cell, header_color)
                 elif alternate_rows and row_idx % 2 == 0:
                     self._set_cell_fill(cell, TABLE_ALT_ROW_FILL)
 
-        return shape
+        return shape, points
 
     # -------------------------------------------------------------------------
     # Image Helpers
     # -------------------------------------------------------------------------
 
-    def _add_image_from_url(
+    def _add_image(
         self,
         slide,
-        image_url: str,
+        source: str,
         left: int,
         top: int,
         max_width: int,
         max_height: int,
         center_horizontal: bool = True,
         center_vertical: bool = False
-    ) -> Optional[Any]:
-        """Download and add an image from URL to a slide.
+    ) -> Tuple[Optional[Any], Optional[str]]:
+        """Add an image from an https URL or an inline data URI.
 
         Args:
             slide: PowerPoint slide object.
-            image_url: URL of the image.
-            left: Left position.
-            top: Top position.
-            max_width: Maximum width.
-            max_height: Maximum height.
+            source: Image URL, or a ``data:image/...;base64,...`` URI.
+            left, top: Position.
+            max_width, max_height: Bounding box the image is scaled into.
             center_horizontal: Whether to center horizontally.
             center_vertical: Whether to center vertically.
 
         Returns:
-            Picture shape or None if failed.
+            ``(picture, None)`` on success, or ``(None, reason)`` — the reason
+            is surfaced to the caller rather than only logged, because an image
+            that quietly failed to load used to produce a confident success
+            response with a placeholder box on the slide.
         """
-        if not image_url:
-            return None
+        if not source:
+            return None, "no image source given"
 
         try:
-            image_data, _ = download_image(image_url)
+            image_data, _ = load_image(source)
 
             picture = slide.shapes.add_picture(
                 image_data, left, top, width=max_width
@@ -480,15 +667,26 @@ class SlideHelpers:
             if center_vertical:
                 picture.top = int(top + (max_height - picture.height) / 2)
 
-            logger.debug(f"Added image from URL: {image_url}")
-            return picture
+            logger.debug("Added image from %s", source[:80])
+            return picture, None
 
         except (ImageDownloadError, ImageValidationError) as e:
-            logger.error(f"Failed to download image: {e}")
-            return None
+            logger.error("Failed to load image: %s", e)
+            return None, str(e)
         except Exception as e:
-            logger.error(f"Failed to add image from URL '{image_url}': {e}", exc_info=True)
-            return None
+            logger.error("Failed to add image from %r: %s", source[:80], e, exc_info=True)
+            return None, str(e)
+
+    def _add_image_from_url(self, slide, image_url: str, left: int, top: int,
+                            max_width: int, max_height: int,
+                            center_horizontal: bool = True,
+                            center_vertical: bool = False) -> Optional[Any]:
+        """Backwards-compatible wrapper returning only the picture."""
+        picture, _ = self._add_image(
+            slide, image_url, left, top, max_width, max_height,
+            center_horizontal, center_vertical,
+        )
+        return picture
 
     def _add_image_placeholder(self, slide, message: str, left: int, top: int, width: int):
         """Add a placeholder text when image cannot be loaded.

--- a/pptx_tools/image_utils.py
+++ b/pptx_tools/image_utils.py
@@ -8,9 +8,12 @@ Downloads are restricted to publicly routable addresses (see
 used to reach loopback, private-network or cloud-metadata services.
 """
 
+import base64
+import binascii
 import io
 import ipaddress
 import logging
+import re
 import socket
 import time
 from typing import Tuple
@@ -258,6 +261,79 @@ def download_image(url: str) -> Tuple[io.BytesIO, str]:
     logger.info(f"Successfully downloaded image: {total_size / 1024:.1f}KB, type: {extension}")
 
     return image_data, extension
+
+
+_DATA_URI_RE = re.compile(
+    r'^data:(?P<mime>[\w.+-]+/[\w.+-]+)?(?P<params>(?:;[^;,]+)*),(?P<data>.*)$',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def is_data_uri(source: str) -> bool:
+    """True when *source* is an inline ``data:`` URI rather than a URL."""
+    return isinstance(source, str) and source[:5].lower() == "data:"
+
+
+def decode_data_uri(source: str) -> Tuple[io.BytesIO, str]:
+    """Decode an inline ``data:image/...;base64,...`` URI.
+
+    Lets a caller place an image it already holds — one a user pasted into the
+    conversation, or a chart it rendered itself — without first publishing it
+    to a URL the server can reach. Nothing leaves the process, so the SSRF
+    checks that guard :func:`download_image` do not apply; the size limit
+    still does.
+
+    Raises:
+        ImageValidationError: If the URI is malformed, is not an allowed image
+            type, or decodes to more than MAX_IMAGE_SIZE bytes.
+    """
+    match = _DATA_URI_RE.match(source)
+    if not match:
+        raise ImageValidationError(
+            "Malformed data URI: expected data:image/png;base64,<base64 data>"
+        )
+
+    mime = (match.group("mime") or "text/plain").lower()
+    params = (match.group("params") or "").lower()
+    payload = match.group("data")
+
+    if mime not in ALLOWED_MIME_TYPES:
+        raise ImageValidationError(
+            f"Invalid image type: {mime}. Allowed types: {', '.join(sorted(ALLOWED_MIME_TYPES))}"
+        )
+
+    if ";base64" not in params:
+        raise ImageValidationError("Only base64-encoded data URIs are supported")
+
+    # Guard before decoding: base64 expands to about 3/4 its length, so a
+    # payload far past the limit is rejected without allocating it.
+    if len(payload) * 3 // 4 > MAX_IMAGE_SIZE:
+        raise ImageValidationError(
+            f"Image too large. Maximum size: {MAX_IMAGE_SIZE / (1024 * 1024):.0f}MB"
+        )
+
+    try:
+        raw = base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise ImageValidationError(f"Could not decode base64 image data: {e}")
+
+    if len(raw) > MAX_IMAGE_SIZE:
+        raise ImageValidationError(
+            f"Image too large: {len(raw) / (1024 * 1024):.1f}MB. "
+            f"Maximum size: {MAX_IMAGE_SIZE / (1024 * 1024):.0f}MB"
+        )
+    if not raw:
+        raise ImageValidationError("Data URI contains no image data")
+
+    logger.info("Decoded inline %s image: %.1fKB", mime, len(raw) / 1024)
+    return io.BytesIO(raw), get_image_extension(mime, "")
+
+
+def load_image(source: str) -> Tuple[io.BytesIO, str]:
+    """Load an image from an https URL or an inline ``data:`` URI."""
+    if is_data_uri(source):
+        return decode_data_uri(source)
+    return download_image(source)
 
 
 def get_image_extension(content_type: str, url: str) -> str:

--- a/pptx_tools/schema.py
+++ b/pptx_tools/schema.py
@@ -365,6 +365,12 @@ def migrate_legacy_slide(slide: Any, seen: Optional[set] = None) -> Any:
         legend_position = out.pop("legend_position", None)
         if has_legend is False:
             used_legacy.append("has_legend")
+            # Contradictory input: "no legend" plus a position for it. The old
+            # renderer tested has_legend first and never read the position, so
+            # keep that precedence — but record the key that lost, or the
+            # deprecation log claims to have accepted something it discarded.
+            if legend_position:
+                used_legacy.append("legend_position")
             out.setdefault("legend", "none")
         elif legend_position:
             used_legacy.append("legend_position")

--- a/pptx_tools/schema.py
+++ b/pptx_tools/schema.py
@@ -1,0 +1,441 @@
+"""Typed slide schema for the PowerPoint tool.
+
+Why this exists
+---------------
+The tool used to take ``slides: List[dict]`` and describe the whole contract in
+a paragraph of prose. Nothing was validated: a typo such as ``text`` instead of
+``slide_text`` produced an empty slide and a success response, and an unknown
+field was silently ignored. Modelling each slide type and joining them with a
+discriminated union gives the client a real JSON schema (``oneOf`` plus a
+``discriminator``), and rejects bad input with a path — ``slides.3.chart.series
+.0.values.2`` — before any rendering happens.
+
+Design notes
+------------
+* **Strict structure, loose values.** ``extra="forbid"`` turns a misspelled key
+  into an error instead of a silently missing element, while table cells accept
+  ``str | int | float | bool | None`` and colours accept ``#RRGGBB``,
+  ``RRGGBB`` or a theme name, because those are the shapes a model actually
+  emits.
+* **Markdown where the model already thinks in markdown.** ``body`` takes
+  either a markdown bullet string or an explicit list of :class:`Bullet`.
+* **Backwards compatible.** :func:`migrate_legacy_slide` maps the previous key
+  names (``slide_type``, ``slide_title``, ``slide_text``,
+  ``indentation_level``, …) onto the new ones. It runs as a *before* validator
+  on the list, ahead of union discrimination, so an old-style payload still
+  validates. Deprecated keys are logged once per call.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+)
+
+from .constants import MAX_INDENT_LEVEL
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Scalars
+# =============================================================================
+
+# 6-digit hex with or without '#', or one of the template's theme colours.
+THEME_COLORS = (
+    "accent1", "accent2", "accent3", "accent4", "accent5", "accent6",
+    "dark1", "dark2", "light1", "light2",
+)
+_HEX_RE = re.compile(r"^#?[0-9A-Fa-f]{6}$")
+
+CellValue = Union[str, int, float, bool, None]
+
+
+def _validate_color(value: Optional[str]) -> Optional[str]:
+    """Accept ``#RRGGBB``, ``RRGGBB`` or a theme colour name."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if _HEX_RE.match(text) or text.lower() in THEME_COLORS:
+        return text
+    raise ValueError(
+        f"{value!r} is not a colour: use 6-digit hex ('#4172C4' or '4172C4') "
+        f"or a theme name ({', '.join(THEME_COLORS)})"
+    )
+
+
+Color = Annotated[str, BeforeValidator(_validate_color)]
+
+
+# =============================================================================
+# Building blocks
+# =============================================================================
+
+def _clamp_level(value: Any) -> Any:
+    """Clamp an indent level into range instead of rejecting it.
+
+    Structure is strict here but values are not: a model that emits level 7,
+    or the string "2", meant a deep bullet, not a failed presentation. The
+    declared bounds stay on the field so the JSON schema still advertises the
+    supported range.
+    """
+    if value is None:
+        return 1
+    try:
+        level = int(value)
+    except (TypeError, ValueError):
+        logger.warning("[pptx] Invalid bullet level %r; using 1", value)
+        return 1
+    return max(1, min(level, MAX_INDENT_LEVEL))
+
+
+class Bullet(BaseModel):
+    """One bullet line. ``level`` is 1-based; 1 is the outermost."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    text: str = Field(description="Bullet text. Inline markdown is supported.")
+    level: Annotated[int, BeforeValidator(_clamp_level)] = Field(
+        default=1, ge=1, le=MAX_INDENT_LEVEL,
+        description=f"Indent depth, 1 (outermost) to {MAX_INDENT_LEVEL}.",
+    )
+
+
+# A body is either a markdown bullet string or explicit bullets.
+Body = Union[str, List[Bullet]]
+
+
+class Column(BaseModel):
+    """One side of a two-column slide."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    heading: Optional[str] = Field(default=None, description="Optional column subheading.")
+    body: Body = Field(default_factory=list, description="Markdown bullets, or explicit bullet objects.")
+
+
+class Series(BaseModel):
+    """One data series of a category chart."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Series name, shown in the legend.")
+    values: List[Optional[float]] = Field(
+        description="One number per category. Use null for a gap."
+    )
+
+
+class XySeries(BaseModel):
+    """One data series of a scatter (XY) chart."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Series name, shown in the legend.")
+    points: List[List[float]] = Field(
+        description="List of [x, y] pairs, e.g. [[1, 4.5], [2, 6.1]]."
+    )
+
+    @field_validator("points")
+    @classmethod
+    def _pairs(cls, points: List[List[float]]) -> List[List[float]]:
+        for i, point in enumerate(points):
+            if len(point) != 2:
+                raise ValueError(f"point {i} must be exactly [x, y], got {len(point)} values")
+        return points
+
+
+# =============================================================================
+# Slides
+# =============================================================================
+
+class SlideBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: Optional[str] = Field(default=None, description="Slide title.")
+    notes: Optional[str] = Field(default=None, description="Speaker notes.")
+    layout: Optional[str] = Field(
+        default=None,
+        description="Layout name from the active template, overriding the default for this slide type.",
+    )
+
+
+class TitleSlide(SlideBase):
+    type: Literal["title"]
+    subtitle: Optional[str] = Field(default=None, description="Subtitle: author, tagline, date…")
+
+
+class SectionSlide(SlideBase):
+    type: Literal["section"]
+
+
+class ContentSlide(SlideBase):
+    type: Literal["content"]
+    body: Body = Field(default_factory=list, description="Markdown bullets, or explicit bullet objects.")
+
+
+class TableSlide(SlideBase):
+    type: Literal["table"]
+    rows: List[List[CellValue]] = Field(
+        description="Rows of cells; the first row is the header. Numbers and nulls are accepted."
+    )
+    align: Optional[List[Literal["left", "center", "right"]]] = Field(
+        default=None, description="Per-column alignment."
+    )
+    header_color: Optional[Color] = Field(default=None, description="Header fill colour.")
+    zebra: bool = Field(default=True, description="Shade alternating rows.")
+    font_size: Optional[int] = Field(default=None, ge=6, le=40, description="Cell font size in points.")
+
+
+class ChartSlide(SlideBase):
+    type: Literal["chart"]
+    chart_type: Literal[
+        "bar", "bar_stacked", "column", "column_stacked",
+        "line", "line_markers", "pie", "doughnut",
+        "area", "area_stacked", "radar",
+    ] = Field(description="Category chart type. For an XY chart use the 'scatter' slide type.")
+    categories: List[str] = Field(description="Category axis labels.")
+    series: List[Series] = Field(description="One or more data series.")
+    legend: Literal["right", "left", "top", "bottom", "none"] = Field(
+        default="right", description="Legend position, or 'none' to hide it."
+    )
+    data_labels: bool = Field(default=False, description="Print the value on each data point.")
+    number_format: Optional[str] = Field(
+        default=None, description="Excel number format for data labels, e.g. '#,##0' or '0.0%'."
+    )
+    chart_title: Optional[str] = Field(default=None, description="Title drawn inside the chart.")
+    x_title: Optional[str] = Field(default=None, description="Category axis title.")
+    y_title: Optional[str] = Field(default=None, description="Value axis title.")
+
+
+class ScatterSlide(SlideBase):
+    type: Literal["scatter"]
+    series: List[XySeries] = Field(description="One or more series of [x, y] points.")
+    legend: Literal["right", "left", "top", "bottom", "none"] = Field(default="right")
+    chart_title: Optional[str] = Field(default=None)
+    x_title: Optional[str] = Field(default=None, description="X axis title.")
+    y_title: Optional[str] = Field(default=None, description="Y axis title.")
+
+
+class ImageSlide(SlideBase):
+    type: Literal["image"]
+    source: str = Field(
+        description="Image https URL, or a data URI (data:image/png;base64,...)."
+    )
+    caption: Optional[str] = Field(default=None, description="Caption under the image.")
+
+
+class TwoColumnSlide(SlideBase):
+    type: Literal["two_column"]
+    left: Column = Field(default_factory=Column, description="Left column.")
+    right: Column = Field(default_factory=Column, description="Right column.")
+
+
+class QuoteSlide(SlideBase):
+    type: Literal["quote"]
+    text: str = Field(description="The quotation, without surrounding quote marks.")
+    attribution: Optional[str] = Field(default=None, description="Who said it.")
+
+
+_SLIDE_MODELS = (
+    TitleSlide, SectionSlide, ContentSlide, TableSlide,
+    ChartSlide, ScatterSlide, ImageSlide, TwoColumnSlide, QuoteSlide,
+)
+
+SLIDE_TYPES = tuple(sorted(m.model_fields["type"].annotation.__args__[0] for m in _SLIDE_MODELS))
+
+AnySlide = Annotated[
+    Union[
+        TitleSlide, SectionSlide, ContentSlide, TableSlide,
+        ChartSlide, ScatterSlide, ImageSlide, TwoColumnSlide, QuoteSlide,
+    ],
+    Field(discriminator="type"),
+]
+
+
+# =============================================================================
+# Legacy key migration
+# =============================================================================
+# The previous schema is still what existing client prompts emit. Map it onto
+# the new keys BEFORE the union discriminates, since discrimination reads
+# "type" and would otherwise reject every old-style slide outright.
+
+_LEGACY_COMMON = {
+    "slide_type": "type",
+    "slide_title": "title",
+    "speaker_notes": "notes",
+}
+
+_LEGACY_BY_TYPE = {
+    "content": {"slide_text": "body"},
+    "table": {"table_data": "rows", "alternate_rows": "zebra"},
+    "image": {"image_url": "source", "image_caption": "caption"},
+    "quote": {"quote_text": "text", "quote_author": "attribution"},
+}
+
+
+def _migrate_bullets(value: Any) -> Any:
+    """Map ``indentation_level`` onto ``level`` and accept bare strings."""
+    if not isinstance(value, list):
+        return value
+    out = []
+    for item in value:
+        if isinstance(item, str):
+            out.append({"text": item})
+        elif isinstance(item, dict):
+            item = dict(item)
+            if "indentation_level" in item and "level" not in item:
+                item["level"] = item.pop("indentation_level")
+            else:
+                item.pop("indentation_level", None)
+            out.append(item)
+        else:
+            out.append(item)
+    return out
+
+
+def migrate_legacy_slide(slide: Any, seen: Optional[set] = None) -> Any:
+    """Return *slide* with any pre-Phase-1 keys renamed to their new names.
+
+    Unrecognised keys are left untouched so ``extra="forbid"`` still reports
+    them; this only translates the spellings the tool used to document.
+    """
+    if not isinstance(slide, dict):
+        return slide
+
+    out = dict(slide)
+    used_legacy = []
+
+    for old, new in _LEGACY_COMMON.items():
+        if old in out:
+            used_legacy.append(old)
+            value = out.pop(old)
+            out.setdefault(new, value)
+
+    slide_type = out.get("type")
+
+    for old, new in _LEGACY_BY_TYPE.get(slide_type, {}).items():
+        if old in out:
+            used_legacy.append(old)
+            value = out.pop(old)
+            out.setdefault(new, value)
+
+    # Bullet lists carry their own legacy key.
+    if slide_type == "content" and isinstance(out.get("body"), list):
+        out["body"] = _migrate_bullets(out["body"])
+
+    # two_column: left_heading/left_column -> left: {heading, body}
+    if slide_type == "two_column":
+        for side in ("left", "right"):
+            heading_key, body_key = f"{side}_heading", f"{side}_column"
+            if heading_key in out or body_key in out:
+                used_legacy.extend(k for k in (heading_key, body_key) if k in out)
+                column: Dict[str, Any] = {}
+                heading = out.pop(heading_key, None)
+                body = out.pop(body_key, None)
+                if heading:
+                    column["heading"] = heading
+                if body is not None:
+                    column["body"] = _migrate_bullets(body)
+                out.setdefault(side, column)
+        for side in ("left", "right"):
+            value = out.get(side)
+            if isinstance(value, dict) and isinstance(value.get("body"), list):
+                value["body"] = _migrate_bullets(value["body"])
+
+    # chart: chart_data{categories,series} -> categories/series; legend flags.
+    if slide_type == "chart":
+        chart_data = out.pop("chart_data", None)
+        if isinstance(chart_data, dict):
+            used_legacy.append("chart_data")
+            if "categories" in chart_data:
+                out.setdefault("categories", chart_data["categories"])
+            if "series" in chart_data:
+                out.setdefault("series", chart_data["series"])
+        has_legend = out.pop("has_legend", None)
+        legend_position = out.pop("legend_position", None)
+        if has_legend is False:
+            used_legacy.append("has_legend")
+            out.setdefault("legend", "none")
+        elif legend_position:
+            used_legacy.append("legend_position")
+            out.setdefault("legend", legend_position)
+        elif has_legend is True:
+            used_legacy.append("has_legend")
+
+    if used_legacy and seen is not None:
+        seen.update(used_legacy)
+
+    return out
+
+
+def _migrate_list(value: Any) -> Any:
+    if not isinstance(value, list):
+        return value
+    seen: set = set()
+    migrated = [migrate_legacy_slide(slide, seen) for slide in value]
+    if seen:
+        logger.info(
+            "[pptx] Accepted deprecated slide keys (%s). The current names are "
+            "documented in the tool description; support will be removed in a "
+            "future release.",
+            ", ".join(sorted(seen)),
+        )
+    return migrated
+
+
+Slides = Annotated[List[AnySlide], BeforeValidator(_migrate_list)]
+
+_SLIDES_ADAPTER: TypeAdapter = TypeAdapter(Slides)
+
+
+# =============================================================================
+# Entry point for non-MCP callers
+# =============================================================================
+
+def _describe_error(error: Dict[str, Any]) -> str:
+    """Render one pydantic error as 'slide 2 -> rows.0: message'."""
+    loc = [str(part) for part in error.get("loc", ())]
+    # Drop the union-member tag pydantic injects so the path reads naturally.
+    index = loc[0] if loc else "?"
+    rest = [part for part in loc[1:] if part not in SLIDE_TYPES]
+    where = f"slide {index}"
+    if rest:
+        where += " -> " + ".".join(rest)
+    return f"{where}: {error.get('msg', 'invalid')}"
+
+
+def coerce_slides(slides: Any) -> List[Any]:
+    """Validate *slides* into typed models, raising a readable ``ValueError``.
+
+    MCP callers never reach the error path — FastMCP validates against the tool
+    signature first — but direct callers (tests, ``create_presentation``) do,
+    and a raw pydantic dump is poor feedback for a model trying to correct
+    itself.
+    """
+    if isinstance(slides, list) and slides and all(
+        isinstance(slide, SlideBase) for slide in slides
+    ):
+        return list(slides)
+
+    try:
+        return _SLIDES_ADAPTER.validate_python(slides)
+    except ValidationError as exc:
+        problems = [_describe_error(error) for error in exc.errors()]
+        # A wrong discriminator produces one error per slide; lead with the
+        # valid types so the fix is obvious.
+        hint = ""
+        if any("does not match any of the expected tags" in problem for problem in problems):
+            hint = f" Valid slide types: {', '.join(SLIDE_TYPES)}."
+        raise ValueError(
+            "Invalid slides: " + "; ".join(problems[:8]) + hint
+        ) from exc

--- a/pptx_tools/slide_builder.py
+++ b/pptx_tools/slide_builder.py
@@ -1,13 +1,19 @@
 """PowerPoint slide builder class.
 
-This module provides the PowerpointPresentation class which builds slides
-from structured data using the SlideHelpers mixin for text, tables, images, etc.
+Builds a deck from the typed slide models in :mod:`pptx_tools.schema`, using
+the SlideHelpers mixin for text, tables, images and charts.
+
+Anything the builder had to work around — an image that would not download, a
+slide whose text will not fit, a layout the template does not provide — is
+recorded on ``self.warnings`` and returned to the caller alongside the file.
+Those situations used to be logged server-side only, so the model was told the
+deck was fine and had no way to correct itself.
 """
 
 import io
 import copy
 import logging
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 from pptx import Presentation
 from pptx.enum.text import PP_ALIGN
@@ -19,16 +25,21 @@ from template_utils import find_pptx_templates
 from .constants import (
     TITLE_LAYOUT, SECTION_LAYOUT, CONTENT_LAYOUT,
     TWO_COLUMN_LAYOUT, TWO_COLUMN_TEXT_LAYOUT,
-    DEFAULT_SUBTITLE_FONT_SIZE, DEFAULT_CAPTION_FONT_SIZE, DEFAULT_QUOTE_FONT_SIZE,
+    DEFAULT_BODY_FONT_SIZE, DEFAULT_SUBTITLE_FONT_SIZE,
+    DEFAULT_CAPTION_FONT_SIZE, DEFAULT_QUOTE_FONT_SIZE,
     TABLE_HEADER_FILL,
     DEFAULT_SLIDE_FORMAT, SLIDE_FORMAT_16_9, VALID_SLIDE_FORMATS,
 )
 from .helpers import (
     SlideHelpers,
-    parse_table_data, parse_color,
+    apply_autofit, body_to_bullets, estimate_text_fill, parse_table_data, resolve_fill, set_runs_language, table_overflows,
 )
 from .inline_formatting import needs_inline_processing, apply_inline_formatting
-from .chart_utils import add_chart_to_slide, ChartDataError
+from .chart_utils import (
+    add_chart_to_slide, add_scatter_to_slide, configure_data_labels,
+    set_axis_titles, ChartDataError,
+)
+from .schema import coerce_slides
 
 logger = logging.getLogger(__name__)
 
@@ -56,47 +67,66 @@ def _get_templates():
 class PowerpointPresentation(SlideHelpers):
     """Builder class for creating PowerPoint presentations from structured data."""
 
-    def __init__(self, slides: List[Dict[str, Any]], format: str,
+    def __init__(self, slides: Sequence[Any], format: str,
                  author: Optional[str] = None,
                  footer_text: Optional[str] = None,
-                 show_slide_numbers: bool = False):
+                 show_slide_numbers: bool = False,
+                 language: Optional[str] = None):
         """Initialize and build presentation.
 
         Args:
-            slides: List of slide dictionaries.
+            slides: Slide models, or plain dicts in either the current or the
+                previous key spelling — both are validated through
+                :func:`~pptx_tools.schema.coerce_slides`.
             format: Presentation format ("4:3" or "16:9").
             author: Author name stored in document metadata/properties.
             footer_text: Optional footer text displayed on all slides.
             show_slide_numbers: Whether to show slide numbers on all slides.
+            language: BCP-47 tag (e.g. "cs-CZ") stamped on every text run so
+                the deck is proof-read in the right language.
         """
-        logger.info(f"Initializing PowerPoint: slides={len(slides)}, format={format}")
-
         if not slides:
             raise ValueError("At least one slide is required")
+
+        self.warnings: List[str] = []
+        self.slides = coerce_slides(slides)
+
+        logger.info(
+            "Initializing PowerPoint: slides=%d, format=%s", len(self.slides), format
+        )
 
         self.presentation = self._create_presentation(format)
         self._footer_text = footer_text
         self._show_slide_numbers = show_slide_numbers
+        self._language = language
         self._remove_template_slides()
-        self._build_slides(slides)
+        self._build_slides(self.slides)
         if footer_text or show_slide_numbers:
             self._apply_footer_and_slide_numbers()
+        if language:
+            self._apply_language(language)
         if author:
             self.presentation.core_properties.author = author
 
+    # -------------------------------------------------------------------------
+    # Setup
+    # -------------------------------------------------------------------------
+
+    def _warn(self, slide_index: int, message: str) -> None:
+        """Record a caller-visible warning about one slide."""
+        entry = f"slide {slide_index}: {message}"
+        self.warnings.append(entry)
+        logger.warning("[pptx] %s", entry)
+
     def _create_presentation(self, format: str) -> Presentation:
-        """Create presentation with appropriate template.
-
-        Args:
-            format: "4:3" or "16:9".
-
-        Returns:
-            Presentation object.
-        """
+        """Create presentation with appropriate template."""
         if format not in VALID_SLIDE_FORMATS:
             logger.warning(
                 "Unknown presentation format %r; using %s. Valid formats: %s",
                 format, DEFAULT_SLIDE_FORMAT, ", ".join(VALID_SLIDE_FORMATS),
+            )
+            self.warnings.append(
+                f"Unknown format {format!r}; used {DEFAULT_SLIDE_FORMAT}."
             )
             format = DEFAULT_SLIDE_FORMAT
 
@@ -108,6 +138,9 @@ class PowerpointPresentation(SlideHelpers):
                 return Presentation(template)
             except Exception as e:
                 logger.error(f"Failed to load template: {e}")
+                self.warnings.append(
+                    f"Template could not be opened ({e}); used the built-in PowerPoint theme."
+                )
 
         logger.warning(f"Using default PowerPoint template for {format}")
         return Presentation()
@@ -115,12 +148,11 @@ class PowerpointPresentation(SlideHelpers):
     def _remove_template_slides(self) -> None:
         """Remove every slide the template ships with, parts included.
 
-        Dropping only the ``<p:sldId>`` entry (what this did previously) leaves
-        the slide's relationship in place, and python-pptx serialises parts by
-        walking relationships — so a template carrying a sample slide shipped
-        that slide's XML, text and images inside every generated file even
-        though PowerPoint showed the right slide count. Dropping the
-        relationship as well removes the part from the saved package.
+        Dropping only the ``<p:sldId>`` entry leaves the slide's relationship in
+        place, and python-pptx serialises parts by walking relationships — so a
+        template carrying a sample slide shipped that slide's XML, text and
+        images inside every generated file even though PowerPoint showed the
+        right slide count. Dropping the relationship removes the part too.
         """
         sldIdLst = self.presentation.slides._sldIdLst
         prs_part = self.presentation.part
@@ -138,13 +170,9 @@ class PowerpointPresentation(SlideHelpers):
         if removed:
             logger.debug("Removed %d slide(s) carried by the template", removed)
 
-    def _build_slides(self, slides: List[Dict[str, Any]]) -> None:
-        """Build all slides from data.
-
-        Args:
-            slides: List of slide dictionaries.
-        """
-        slide_builders = {
+    def _build_slides(self, slides: Sequence[Any]) -> None:
+        """Build all slides from validated models."""
+        builders = {
             "title": self._build_title_slide,
             "section": self._build_section_slide,
             "content": self._build_content_slide,
@@ -152,259 +180,276 @@ class PowerpointPresentation(SlideHelpers):
             "image": self._build_image_slide,
             "two_column": self._build_two_column_slide,
             "chart": self._build_chart_slide,
+            "scatter": self._build_scatter_slide,
             "quote": self._build_quote_slide,
         }
 
-        logger.info(f"Building {len(slides)} slides")
+        logger.info("Building %d slides", len(slides))
 
-        for i, slide_data in enumerate(slides):
-            if not isinstance(slide_data, dict):
-                raise ValueError(
-                    f"Slide {i} must be an object with a 'slide_type' field, got {type(slide_data).__name__}"
-                )
+        for i, slide in enumerate(slides):
+            builder = builders.get(slide.type)
+            if builder is None:  # pragma: no cover - schema forbids it
+                raise ValueError(f"No builder for slide type {slide.type!r} at slide {i}")
 
-            slide_type = slide_data.get("slide_type", "")
-            builder = slide_builders.get(slide_type)
-
-            if builder is None:
-                # Previously this only logged a warning: the slide was dropped and
-                # the caller still received a success response quoting the number
-                # of slides it had asked for. Fail loudly so the model can correct
-                # the type instead of shipping a deck with holes in it.
-                raise ValueError(
-                    f"Unknown slide_type {slide_type!r} at slide {i}. "
-                    f"Valid types: {', '.join(sorted(slide_builders))}"
+            # `layout` is accepted now and honoured once template layouts are
+            # resolved by name; say so rather than ignoring it silently.
+            if slide.layout:
+                self._warn(
+                    i,
+                    f"layout {slide.layout!r} was ignored: named layouts are not "
+                    "resolved yet, the default layout for this slide type was used.",
                 )
 
             try:
-                logger.debug(f"Building slide {i}: type={slide_type}")
-                builder(slide_data)
+                logger.debug("Building slide %d: type=%s", i, slide.type)
+                builder(slide, i)
             except Exception as e:
-                logger.error(f"Failed to create slide {i}: {e}")
-                raise ValueError(f"Error creating slide {i} ({slide_type}): {e}")
+                logger.error("Failed to create slide %d: %s", i, e)
+                raise ValueError(f"Error creating slide {i} ({slide.type}): {e}")
 
     # -------------------------------------------------------------------------
     # Slide Builders
     # -------------------------------------------------------------------------
 
-    def _build_title_slide(self, data: Dict[str, Any]) -> None:
+    def _build_title_slide(self, slide_data, index: int) -> None:
         """Build a title slide with title and optional subtitle."""
         layout = self.presentation.slide_layouts[TITLE_LAYOUT]
         slide = self.presentation.slides.add_slide(layout)
 
         if len(slide.placeholders) > 0:
-            slide.placeholders[0].text = data.get("slide_title", "")
+            slide.placeholders[0].text = slide_data.title or ""
         if len(slide.placeholders) > 1:
-            slide.placeholders[1].text = data.get("subtitle", "")
+            slide.placeholders[1].text = slide_data.subtitle or ""
 
-        self._add_speaker_notes(slide, data.get("speaker_notes"))
+        self._add_speaker_notes(slide, slide_data.notes)
 
-    def _build_section_slide(self, data: Dict[str, Any]) -> None:
+    def _build_section_slide(self, slide_data, index: int) -> None:
         """Build a section divider slide."""
         layout = self.presentation.slide_layouts[SECTION_LAYOUT]
         slide = self.presentation.slides.add_slide(layout)
 
         if len(slide.placeholders) > 0:
-            slide.placeholders[0].text = data.get("slide_title", "")
+            slide.placeholders[0].text = slide_data.title or ""
 
-        self._add_speaker_notes(slide, data.get("speaker_notes"))
+        self._add_speaker_notes(slide, slide_data.notes)
 
-    def _build_content_slide(self, data: Dict[str, Any]) -> None:
+    def _build_content_slide(self, slide_data, index: int) -> None:
         """Build a content slide with bullet points."""
         layout = self.presentation.slide_layouts[CONTENT_LAYOUT]
         slide = self.presentation.slides.add_slide(layout)
 
-        # Title
         if len(slide.placeholders) > 0:
-            slide.placeholders[0].text = data.get("slide_title", "")
+            slide.placeholders[0].text = slide_data.title or ""
 
-        # Bullet points — use shared _fill_bullets method
-        slide_text = data.get("slide_text", [])
-        if slide_text and len(slide.placeholders) > 1:
+        bullets = body_to_bullets(slide_data.body)
+        if bullets and len(slide.placeholders) > 1:
             placeholder = slide.placeholders[1]
             placeholder.text = ""
-            self._fill_bullets(placeholder.text_frame, slide_text)
+            self._fill_bullets(placeholder.text_frame, bullets)
+            self._fit_text(placeholder, bullets, index)
 
-        self._add_speaker_notes(slide, data.get("speaker_notes"))
+        self._add_speaker_notes(slide, slide_data.notes)
 
-    def _build_table_slide(self, data: Dict[str, Any]) -> None:
-        """Build a table slide with styled table using Title and Content layout."""
-        title = data.get("slide_title", "")
-        slide, left, top, width, height = self._add_title_content_slide(title)
+    def _build_table_slide(self, slide_data, index: int) -> None:
+        """Build a table slide with a styled table."""
+        slide, left, top, width, height = self._add_title_content_slide(slide_data.title or "")
 
-        # Table — parse_table_data returns (cleaned_rows, column_alignments)
-        table_data, col_alignments = parse_table_data(data.get("table_data", []))
-        if not table_data:
-            logger.warning("No table data provided")
+        rows, col_alignments = parse_table_data(slide_data.rows)
+        if not rows:
+            self._warn(index, "table has no rows; the slide is empty.")
             return
 
-        header_color = parse_color(
-            data.get("header_color", "4172C4"),
-            TABLE_HEADER_FILL
-        )
+        # An explicit `align` beats an inline markdown separator row.
+        if slide_data.align:
+            col_alignments = [
+                {"left": PP_ALIGN.LEFT, "center": PP_ALIGN.CENTER, "right": PP_ALIGN.RIGHT}[a]
+                for a in slide_data.align
+            ]
 
-        self._create_styled_table(
+        header_fill = resolve_fill(slide_data.header_color, TABLE_HEADER_FILL)
+
+        _, points = self._create_styled_table(
             slide,
-            table_data,
+            rows,
             left=left,
             top=top,
             width=width,
             height=height,
-            header_color=header_color,
-            alternate_rows=data.get("alternate_rows", True),
+            header_color=header_fill,
+            alternate_rows=slide_data.zebra,
             column_alignments=col_alignments,
+            font_size=slide_data.font_size,
         )
 
-        self._add_speaker_notes(slide, data.get("speaker_notes"))
-
-    def _build_image_slide(self, data: Dict[str, Any]) -> None:
-        """Build a slide with an image from URL using Title and Content layout."""
-        title = data.get("slide_title", "")
-        slide, left, top, width, height = self._add_title_content_slide(title)
-
-        # Image
-        image_url = data.get("image_url", "")
-        caption = data.get("image_caption", "")
-
-        max_height = height - (Inches(0.6) if caption else 0)
-
-        if image_url:
-            picture = self._add_image_from_url(
-                slide, image_url,
-                left=left,
-                top=top,
-                max_width=width,
-                max_height=max_height
+        if points and table_overflows(len(rows), height, points):
+            self._warn(
+                index,
+                f"table of {len(rows)} rows will not fit the content area even at "
+                f"{points}pt; split it across slides.",
+            )
+        elif slide_data.font_size is None and points and points < int(DEFAULT_BODY_FONT_SIZE.pt):
+            self._warn(
+                index,
+                f"table font reduced to {points}pt to fit {len(rows)} rows.",
             )
 
-            if picture and caption:
-                self._add_text_box(
-                    slide, caption,
-                    left=left,
-                    top=picture.top + picture.height + Inches(0.1),
-                    width=width,
-                    height=Inches(0.5),
-                    font_size=DEFAULT_CAPTION_FONT_SIZE,
-                    italic=True,
-                    alignment=PP_ALIGN.CENTER
-                )
-            elif not picture:
-                self._add_image_placeholder(
-                    slide, "Image could not be loaded",
-                    left, top + Inches(1), width
-                )
+        self._add_speaker_notes(slide, slide_data.notes)
 
-        self._add_speaker_notes(slide, data.get("speaker_notes"))
+    def _build_image_slide(self, slide_data, index: int) -> None:
+        """Build a slide with an image from a URL or inline data URI."""
+        slide, left, top, width, height = self._add_title_content_slide(slide_data.title or "")
 
-    def _build_two_column_slide(self, data: Dict[str, Any]) -> None:
+        caption = slide_data.caption
+        max_height = height - (Inches(0.6) if caption else 0)
+
+        picture, error = self._add_image(
+            slide, slide_data.source,
+            left=left, top=top, max_width=width, max_height=max_height,
+        )
+
+        if picture and caption:
+            self._add_text_box(
+                slide, caption,
+                left=left,
+                top=picture.top + picture.height + Inches(0.1),
+                width=width,
+                height=Inches(0.5),
+                font_size=DEFAULT_CAPTION_FONT_SIZE,
+                italic=True,
+                alignment=PP_ALIGN.CENTER,
+            )
+        elif not picture:
+            self._add_image_placeholder(
+                slide, "Image could not be loaded", left, top + Inches(1), width
+            )
+            self._warn(index, f"image could not be loaded ({error}); a placeholder was drawn.")
+
+        self._add_speaker_notes(slide, slide_data.notes)
+
+    def _build_two_column_slide(self, slide_data, index: int) -> None:
         """Build a slide with two text columns using built-in PowerPoint layouts.
 
-        Uses TWO_COLUMN_TEXT_LAYOUT (Comparison) if subheaders are provided,
-        otherwise uses TWO_COLUMN_LAYOUT (Two Content).
+        Uses the Comparison layout when either column has a heading, otherwise
+        Two Content.
 
         Placeholder indices:
         - Two Content (3): idx 0=Title, 1=Left content, 2=Right content
-        - Comparison (4): idx 0=Title, 1=Left subheader, 2=Left content, 3=Right subheader, 4=Right content
+        - Comparison (4): idx 0=Title, 1=Left heading, 2=Left content,
+          3=Right heading, 4=Right content
         """
-        left_heading = data.get("left_heading", "")
-        right_heading = data.get("right_heading", "")
-        has_subheaders = bool(left_heading or right_heading)
+        left_col, right_col = slide_data.left, slide_data.right
+        has_headings = bool(left_col.heading or right_col.heading)
 
-        # Choose layout based on whether subheaders are needed
-        if has_subheaders:
-            layout = self.presentation.slide_layouts[TWO_COLUMN_TEXT_LAYOUT]
+        layout_index = TWO_COLUMN_TEXT_LAYOUT if has_headings else TWO_COLUMN_LAYOUT
+        slide = self.presentation.slides.add_slide(self.presentation.slide_layouts[layout_index])
+
+        left_bullets = body_to_bullets(left_col.body)
+        right_bullets = body_to_bullets(right_col.body)
+
+        if has_headings:
+            content_slots = {2: left_bullets, 4: right_bullets}
+            heading_slots = {1: left_col.heading, 3: right_col.heading}
         else:
-            layout = self.presentation.slide_layouts[TWO_COLUMN_LAYOUT]
+            content_slots = {1: left_bullets, 2: right_bullets}
+            heading_slots = {}
 
-        slide = self.presentation.slides.add_slide(layout)
-
-        # Fill placeholders based on layout type
         for shape in slide.placeholders:
             idx = shape.placeholder_format.idx
 
-            # Title placeholder (idx 0) - both layouts
             if idx == 0:
-                title = data.get("slide_title", "")
-                if title:
-                    shape.text = title
+                if slide_data.title:
+                    shape.text = slide_data.title
+            elif idx in heading_slots:
+                if heading_slots[idx]:
+                    shape.text = heading_slots[idx]
+            elif idx in content_slots:
+                bullets = content_slots[idx]
+                if bullets:
+                    self._fill_bullets(shape.text_frame, bullets)
+                    self._fit_text(shape, bullets, index)
 
-            elif has_subheaders:
-                # Comparison layout indices
-                if idx == 1:  # Left subheader
-                    if left_heading:
-                        shape.text = left_heading
-                elif idx == 2:  # Left content
-                    self._fill_bullets(shape.text_frame, data.get("left_column", []))
-                elif idx == 3:  # Right subheader
-                    if right_heading:
-                        shape.text = right_heading
-                elif idx == 4:  # Right content
-                    self._fill_bullets(shape.text_frame, data.get("right_column", []))
-            else:
-                # Two Content layout indices
-                if idx == 1:  # Left content
-                    self._fill_bullets(shape.text_frame, data.get("left_column", []))
-                elif idx == 2:  # Right content
-                    self._fill_bullets(shape.text_frame, data.get("right_column", []))
+        self._add_speaker_notes(slide, slide_data.notes)
 
-        self._add_speaker_notes(slide, data.get("speaker_notes"))
+    def _build_chart_slide(self, slide_data, index: int) -> None:
+        """Build a slide with a category chart."""
+        slide, left, top, width, height = self._add_title_content_slide(slide_data.title or "")
 
-
-    def _build_chart_slide(self, data: Dict[str, Any]) -> None:
-        """Build a slide with a chart using Title and Content layout."""
-        title = data.get("slide_title", "")
-        slide, left, top, width, height = self._add_title_content_slide(title)
-
-        # Chart
-        chart_data = data.get("chart_data", {})
-        if not chart_data:
-            self._add_text_box(
-                slide, "[No chart data provided]",
-                left, top, width, Inches(1),
-                alignment=PP_ALIGN.CENTER
-            )
-            return
+        chart_data = {
+            "categories": slide_data.categories,
+            "series": [
+                {"name": s.name, "values": s.values} for s in slide_data.series
+            ],
+        }
 
         try:
-            add_chart_to_slide(
+            chart = add_chart_to_slide(
                 slide,
-                chart_type=data.get("chart_type", "bar"),
+                chart_type=slide_data.chart_type,
                 chart_data=chart_data,
-                left=left,
-                top=top,
-                width=width,
-                height=height,
-                has_legend=data.get("has_legend", True),
-                legend_position=data.get("legend_position", "right")
+                left=left, top=top, width=width, height=height,
+                has_legend=slide_data.legend != "none",
+                legend_position=slide_data.legend,
+                title=slide_data.chart_title,
             )
+            configure_data_labels(chart, slide_data.data_labels, slide_data.number_format)
+            set_axis_titles(chart, slide_data.x_title, slide_data.y_title)
         except ChartDataError as e:
             logger.error(f"Chart error: {e}")
             self._add_text_box(
                 slide, f"[Chart error: {e}]",
-                left, top, width, Inches(1),
-                alignment=PP_ALIGN.CENTER
+                left, top, width, Inches(1), alignment=PP_ALIGN.CENTER,
             )
+            self._warn(index, f"chart could not be built ({e}).")
+            self._add_speaker_notes(slide, slide_data.notes)
+            return
 
-        self._add_speaker_notes(slide, data.get("speaker_notes"))
+        # A series whose length disagrees with the categories is accepted by
+        # python-pptx but renders with gaps, so say so rather than let it pass.
+        for series in slide_data.series:
+            if len(series.values) != len(slide_data.categories):
+                self._warn(
+                    index,
+                    f"series {series.name!r} has {len(series.values)} values for "
+                    f"{len(slide_data.categories)} categories.",
+                )
 
+        self._add_speaker_notes(slide, slide_data.notes)
 
-    def _build_quote_slide(self, data: Dict[str, Any]) -> None:
-        """Build a quote/citation slide using Title and Content layout."""
-        title = data.get("slide_title", "")
-        slide, left, top, width, height = self._add_title_content_slide(title)
+    def _build_scatter_slide(self, slide_data, index: int) -> None:
+        """Build a slide with an XY (scatter) chart."""
+        slide, left, top, width, height = self._add_title_content_slide(slide_data.title or "")
 
-        # Quote
-        quote_text = data.get("quote_text", "")
-        quote_author = data.get("quote_author", "")
+        try:
+            add_scatter_to_slide(
+                slide,
+                series=slide_data.series,
+                left=left, top=top, width=width, height=height,
+                legend=slide_data.legend,
+                title=slide_data.chart_title,
+                x_title=slide_data.x_title,
+                y_title=slide_data.y_title,
+            )
+        except ChartDataError as e:
+            logger.error(f"Scatter chart error: {e}")
+            self._add_text_box(
+                slide, f"[Chart error: {e}]",
+                left, top, width, Inches(1), alignment=PP_ALIGN.CENTER,
+            )
+            self._warn(index, f"scatter chart could not be built ({e}).")
+
+        self._add_speaker_notes(slide, slide_data.notes)
+
+    def _build_quote_slide(self, slide_data, index: int) -> None:
+        """Build a quote/citation slide."""
+        slide, left, top, width, height = self._add_title_content_slide(slide_data.title or "")
 
         quote_box = slide.shapes.add_textbox(left, top, width, height)
         tf = quote_box.text_frame
         tf.word_wrap = True
 
-        # Quote text — support inline markdown formatting
         para = tf.paragraphs[0]
         para.alignment = PP_ALIGN.CENTER
-        formatted_quote = f'"{quote_text}"'
+        formatted_quote = f'"{slide_data.text}"'
         if needs_inline_processing(formatted_quote):
             apply_inline_formatting(para, formatted_quote,
                                     font_size=DEFAULT_QUOTE_FONT_SIZE, italic=True)
@@ -413,20 +458,51 @@ class PowerpointPresentation(SlideHelpers):
             para.font.size = DEFAULT_QUOTE_FONT_SIZE
             para.font.italic = True
 
-        # Author
-        if quote_author:
+        if slide_data.attribution:
             author_para = tf.add_paragraph()
-            author_para.text = f"— {quote_author}"
+            author_para.text = f"— {slide_data.attribution}"
             author_para.font.size = DEFAULT_SUBTITLE_FONT_SIZE
             author_para.font.bold = True
             author_para.alignment = PP_ALIGN.CENTER
             author_para.space_before = Pt(24)
 
-        self._add_speaker_notes(slide, data.get("speaker_notes"))
+        self._add_speaker_notes(slide, slide_data.notes)
 
     # -------------------------------------------------------------------------
-    # Footer & Slide Numbers
+    # Fit, language, footer
     # -------------------------------------------------------------------------
+
+    def _fit_text(self, placeholder, bullets, index: int) -> None:
+        """Ask PowerPoint to shrink overfull body text, and warn when it is far gone."""
+        fill = estimate_text_fill(
+            bullets, placeholder.width, placeholder.height,
+            font_size_pt=float(DEFAULT_BODY_FONT_SIZE.pt),
+        )
+        apply_autofit(placeholder.text_frame, scale=(1.0 / fill) if fill > 1.0 else None)
+
+        # Below the shrink floor the slide is genuinely overfull; shrinking
+        # further would produce text nobody can read from a room.
+        if fill > 1.0 / 0.6:
+            self._warn(
+                index,
+                f"body text is about {fill:.1f}x the space available and will be "
+                "shrunk to fit; consider splitting it across slides.",
+            )
+
+    def _apply_language(self, language: str) -> None:
+        """Stamp the proofing language on every run in the deck."""
+        for slide in self.presentation.slides:
+            for shape in slide.shapes:
+                if shape.has_text_frame:
+                    set_runs_language(shape.text_frame, language)
+                elif getattr(shape, "has_table", False):
+                    for row in shape.table.rows:
+                        for cell in row.cells:
+                            set_runs_language(cell.text_frame, language)
+            if slide.has_notes_slide:
+                set_runs_language(slide.notes_slide.notes_text_frame, language)
+
+        logger.debug("Applied language %s to all runs", language)
 
     def _apply_footer_and_slide_numbers(self) -> None:
         """Apply footer text and/or slide numbers to all slides.
@@ -436,6 +512,8 @@ class PowerpointPresentation(SlideHelpers):
         shape IDs to avoid PPTX corruption.
         """
         from xml.sax.saxutils import escape as xml_escape
+
+        missing_footer = 0
 
         for slide in self.presentation.slides:
             layout = slide.slide_layout
@@ -452,20 +530,21 @@ class PowerpointPresentation(SlideHelpers):
                     existing_ids.add(int(cNvPr.get('id')))
             next_id = max(existing_ids, default=0) + 1
 
+            layout_indices = {ph.placeholder_format.idx for ph in layout.placeholders}
+            if self._footer_text and 11 not in layout_indices:
+                missing_footer += 1
+
             for ph in layout.placeholders:
                 idx = ph.placeholder_format.idx
 
                 if idx == 11 and self._footer_text:  # FOOTER placeholder
                     sp = copy.deepcopy(ph._element)
-                    # Assign unique shape ID
                     cNvPr = sp.find(qn('p:nvSpPr') + '/' + qn('p:cNvPr'))
                     if cNvPr is not None:
                         cNvPr.set('id', str(next_id))
                         next_id += 1
-                    # Set footer text in the cloned element
                     txBody = sp.find(qn('p:txBody'))
                     if txBody is not None:
-                        # Clear existing paragraphs and add our text
                         for p in txBody.findall(qn('a:p')):
                             txBody.remove(p)
                         ns = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
@@ -476,12 +555,19 @@ class PowerpointPresentation(SlideHelpers):
 
                 elif idx == 12 and self._show_slide_numbers:  # SLIDE_NUMBER placeholder
                     sp = copy.deepcopy(ph._element)
-                    # Assign unique shape ID
                     cNvPr = sp.find(qn('p:nvSpPr') + '/' + qn('p:cNvPr'))
                     if cNvPr is not None:
                         cNvPr.set('id', str(next_id))
                         next_id += 1
                     spTree.append(sp)
+
+        if missing_footer:
+            # Previously this just produced a deck with no footer and no
+            # explanation of why the argument appeared to do nothing.
+            self.warnings.append(
+                f"footer_text was dropped on {missing_footer} slide(s): their layout "
+                "has no footer placeholder."
+            )
 
         logger.debug("Applied footer/slide numbers to all slides")
 
@@ -507,4 +593,3 @@ class PowerpointPresentation(SlideHelpers):
         except Exception as e:
             logger.error("Failed to save PowerPoint presentation: %s", e, exc_info=True)
             raise RuntimeError(f"Failed to save presentation: {e}") from e
-

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -285,15 +285,23 @@ class TestBufferFunctions:
         result.close()
 
     def test_create_presentation_buffer(self):
-        """Test _create_presentation_buffer returns BytesIO."""
+        """_create_presentation_buffer returns (BytesIO, warnings).
+
+        Unlike the other _create_*_buffer helpers it returns a pair: the
+        PowerPoint builder reports what it had to work around (an image that
+        would not load, text shrunk to fit) and the caller passes that back to
+        the model rather than leaving it in the server log.
+        """
         from pptx_tools import _create_presentation_buffer
 
         slides = [
             {"slide_type": "title", "slide_title": "Test Presentation", "subtitle": "Test"}
         ]
-        result = _create_presentation_buffer(slides)
+        result, warnings = _create_presentation_buffer(slides)
 
         assert isinstance(result, io.BytesIO)
+        assert isinstance(warnings, list)
+        assert warnings == []
         assert result.tell() == 0
         content = result.read()
         assert len(content) > 0

--- a/tests/test_pptx_creation.py
+++ b/tests/test_pptx_creation.py
@@ -507,17 +507,9 @@ class TestImageSlides:
         path = save_presentation(pres, "23_image_placeholder.pptx")
         assert path.exists()
 
-    def test_image_slide_no_url(self):
-        """Test image slide without URL."""
-        slides = [
-            {
-                "slide_type": "image",
-                "slide_title": "Image Slide (No URL)"
-            }
-        ]
-        pres = PowerpointPresentation(slides, "16:9")
-        path = save_presentation(pres, "24_image_no_url.pptx")
-        assert path.exists()
+    # test_image_slide_no_url moved to test_pptx_schema.py: an image slide with
+    # no source is now rejected by the schema rather than producing an empty
+    # slide, and asserting that needs no network access.
 
 
 

--- a/tests/test_pptx_robustness.py
+++ b/tests/test_pptx_robustness.py
@@ -140,7 +140,7 @@ class TestUnknownSlideType:
         assert len(reload_presentation(pres).slides) == len(slides)
 
     def test_non_dict_slide_raises(self):
-        with pytest.raises(ValueError, match="must be an object"):
+        with pytest.raises(ValueError, match="valid dictionary or object"):
             build(["just a string"])
 
 
@@ -306,14 +306,15 @@ class TestIndentationLevel:
 
 class TestChartTypes:
 
-    def test_scatter_is_rejected_with_advice(self):
+    def test_scatter_as_a_category_chart_type_points_at_the_slide_type(self):
+        """Scatter is a slide type now, so asking for it here names the fix."""
         with pytest.raises(ChartDataError) as excinfo:
             validate_chart_data(
                 {"categories": ["a"], "series": [{"name": "s", "values": [1]}]}, "scatter"
             )
         message = str(excinfo.value)
-        assert "not supported" in message
-        assert "line_markers" in message
+        assert "own slide type" in message
+        assert '"type": "scatter"' in message
 
     def test_scatter_is_not_advertised(self):
         assert "scatter" not in CHART_TYPE_MAP

--- a/tests/test_pptx_schema.py
+++ b/tests/test_pptx_schema.py
@@ -21,6 +21,7 @@ from pptx.util import Emu
 
 from pptx_tools.helpers import body_to_bullets, estimate_text_fill, fit_table_font_size
 from pptx_tools.image_utils import ImageValidationError, decode_data_uri, is_data_uri
+from pptx_tools.chart_utils import ChartDataError
 from pptx_tools.schema import (
     Bullet, ContentSlide, SLIDE_TYPES, _SLIDES_ADAPTER, coerce_slides,
 )
@@ -172,6 +173,31 @@ class TestLegacyKeys:
         }])[0]
         assert slide.legend == "none"
 
+    def test_contradictory_legend_keys_keep_the_old_precedence_and_are_logged(self):
+        """has_legend=false wins over legend_position, as the old renderer did.
+
+        The loser must still be recorded, or the deprecation log claims to
+        have accepted a key whose value it discarded.
+        """
+        from pptx_tools.schema import migrate_legacy_slide
+
+        seen = set()
+        out = migrate_legacy_slide({
+            "slide_type": "chart", "chart_type": "pie",
+            "chart_data": {"categories": ["a"], "series": [{"name": "s", "values": [1]}]},
+            "has_legend": False, "legend_position": "top",
+        }, seen)
+
+        assert out["legend"] == "none"
+        assert "has_legend" in seen
+        assert "legend_position" in seen
+
+    def test_new_style_key_wins_over_its_legacy_spelling(self):
+        slide = coerce_slides([{
+            "slide_type": "section", "slide_title": "old", "title": "new",
+        }])[0]
+        assert slide.title == "new"
+
     def test_out_of_range_level_is_clamped_not_rejected(self):
         """Phase 0 clamped these; the typed schema must not turn it into an error."""
         slide = coerce_slides([{
@@ -270,6 +296,34 @@ class TestCharts:
         }])
         chart = [s.chart for s in reload_presentation(pres).slides[0].shapes if s.has_chart][0]
         assert len(chart.plots[0].series) == 2
+
+    def test_empty_series_name_is_kept_not_treated_as_missing(self):
+        """`getattr(...) or ...` could not tell "absent" from "empty string"."""
+        from pptx_tools.chart_utils import _series_field
+        from pptx_tools.schema import XySeries
+
+        assert _series_field(XySeries(name="", points=[[1, 2]]), "name") == ""
+        assert _series_field({"name": "", "points": [[1, 2]]}, "name") == ""
+        assert _series_field(XySeries(name="s", points=[[1, 2]]), "missing") is None
+
+    def test_scatter_series_without_a_name_is_reported(self):
+        from pptx_tools.chart_utils import add_scatter_to_slide
+
+        pres = build([{"type": "title", "title": "T"}])
+        slide = pres.presentation.slides[0]
+        with pytest.raises(ChartDataError, match="no name"):
+            add_scatter_to_slide(slide, [{"points": [[1, 2]]}], 0, 0, 100, 100)
+
+    def test_scatter_accepts_plain_dict_series(self):
+        """The library entry point is exported, so the dict path must work."""
+        from pptx_tools.chart_utils import add_scatter_to_slide
+
+        pres = build([{"type": "title", "title": "T"}])
+        slide = pres.presentation.slides[0]
+        chart = add_scatter_to_slide(
+            slide, [{"name": "d", "points": [[1, 2], [3, 4]]}], 0, 0, 4000000, 3000000
+        )
+        assert len(chart.plots[0].series) == 1
 
     def test_data_labels_and_number_format(self):
         pres = build([{

--- a/tests/test_pptx_schema.py
+++ b/tests/test_pptx_schema.py
@@ -1,0 +1,514 @@
+"""Tests for the typed slide schema (review Phase 1).
+
+Covers the contract itself — discrimination, validation, the legacy-key shim,
+markdown bodies — and the behaviour it unlocked: real scatter charts, chart
+options, inline images, autofit and the warnings channel.
+"""
+
+import base64
+import io
+import json
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import pytest
+from pptx import Presentation as PptxReader
+from pptx.oxml.ns import qn
+from pptx.util import Emu
+
+from pptx_tools.helpers import body_to_bullets, estimate_text_fill, fit_table_font_size
+from pptx_tools.image_utils import ImageValidationError, decode_data_uri, is_data_uri
+from pptx_tools.schema import (
+    Bullet, ContentSlide, SLIDE_TYPES, _SLIDES_ADAPTER, coerce_slides,
+)
+from pptx_tools.slide_builder import PowerpointPresentation
+
+# A 1x1 transparent PNG.
+PNG_1PX = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+PNG_DATA_URI = "data:image/png;base64," + base64.b64encode(PNG_1PX).decode()
+
+
+def build(slides, fmt="16:9", **kwargs):
+    return PowerpointPresentation(slides, fmt, **kwargs)
+
+
+def reload_presentation(pres):
+    return PptxReader(pres.save())
+
+
+def body_paragraphs(slide):
+    for shape in slide.shapes:
+        if not shape.has_text_frame:
+            continue
+        if shape.is_placeholder and shape.placeholder_format.idx == 0:
+            continue
+        if shape.text_frame.text.strip():
+            return shape.text_frame.paragraphs
+    raise AssertionError("No body text frame on slide")
+
+
+# =============================================================================
+# The contract
+# =============================================================================
+
+class TestSchemaShape:
+
+    def test_json_schema_is_discriminated(self):
+        schema = _SLIDES_ADAPTER.json_schema()
+        items = schema.get("items", schema)
+        assert "oneOf" in items
+        assert "discriminator" in items
+        # One definition per slide type, so the model sees each type's fields.
+        assert len(schema["$defs"]) >= len(SLIDE_TYPES)
+
+    def test_every_slide_type_is_reachable(self):
+        assert set(SLIDE_TYPES) == {
+            "title", "section", "content", "table",
+            "chart", "scatter", "image", "two_column", "quote",
+        }
+
+    def test_unknown_type_names_the_valid_ones(self):
+        with pytest.raises(ValueError) as excinfo:
+            coerce_slides([{"type": "bullets", "title": "x"}])
+        message = str(excinfo.value)
+        assert "bullets" in message
+        assert "Valid slide types" in message
+        assert "two_column" in message
+
+    def test_misspelled_field_is_rejected_not_ignored(self):
+        """The whole point of extra='forbid': a typo used to make an empty slide."""
+        with pytest.raises(ValueError) as excinfo:
+            coerce_slides([{"type": "quote", "txt": "hello"}])
+        assert "txt" in str(excinfo.value)
+
+    def test_error_names_the_slide_and_field(self):
+        with pytest.raises(ValueError) as excinfo:
+            coerce_slides([
+                {"type": "section", "title": "ok"},
+                {"type": "chart", "title": "c", "chart_type": "pie",
+                 "categories": ["a"], "series": [{"name": "s", "values": ["nope"]}]},
+            ])
+        message = str(excinfo.value)
+        assert "slide 1" in message
+        assert "series.0.values.0" in message
+
+    def test_bad_colour_is_rejected_with_guidance(self):
+        with pytest.raises(ValueError) as excinfo:
+            coerce_slides([{"type": "table", "rows": [["a"]], "header_color": "cornflower"}])
+        assert "6-digit hex" in str(excinfo.value)
+
+    @pytest.mark.parametrize("value", ["#C00000", "c00000", "accent1", "dark2"])
+    def test_accepted_colours(self, value):
+        slides = coerce_slides([{"type": "table", "rows": [["a"]], "header_color": value}])
+        assert slides[0].header_color == value
+
+    def test_scatter_points_must_be_pairs(self):
+        with pytest.raises(ValueError) as excinfo:
+            coerce_slides([{"type": "scatter", "series": [{"name": "s", "points": [[1, 2, 3]]}]}])
+        assert "exactly [x, y]" in str(excinfo.value)
+
+
+# =============================================================================
+# Legacy compatibility
+# =============================================================================
+
+class TestLegacyKeys:
+    """Prompts written against the previous key names must keep working."""
+
+    def test_legacy_deck_still_builds(self):
+        legacy = [
+            {"slide_type": "title", "slide_title": "Deck", "subtitle": "sub"},
+            {"slide_type": "section", "slide_title": "Part 1"},
+            {"slide_type": "content", "slide_title": "Body",
+             "slide_text": [{"text": "a", "indentation_level": 1},
+                            {"text": "b", "indentation_level": 2}],
+             "speaker_notes": "notes"},
+            {"slide_type": "table", "slide_title": "T",
+             "table_data": [["A", "B"], ["1", "2"]], "alternate_rows": False},
+            {"slide_type": "two_column", "slide_title": "2c",
+             "left_heading": "L", "left_column": [{"text": "l", "indentation_level": 1}],
+             "right_heading": "R", "right_column": [{"text": "r", "indentation_level": 1}]},
+            {"slide_type": "chart", "slide_title": "Ch", "chart_type": "column",
+             "chart_data": {"categories": ["a"], "series": [{"name": "s", "values": [1]}]},
+             "has_legend": False},
+            {"slide_type": "quote", "quote_text": "q", "quote_author": "me"},
+        ]
+        pres = build(legacy)
+        assert len(reload_presentation(pres).slides) == len(legacy)
+
+    def test_legacy_keys_map_onto_new_fields(self):
+        slides = coerce_slides([{
+            "slide_type": "content", "slide_title": "T",
+            "slide_text": [{"text": "x", "indentation_level": 3}],
+            "speaker_notes": "n",
+        }])
+        slide = slides[0]
+        assert slide.type == "content"
+        assert slide.title == "T"
+        assert slide.notes == "n"
+        assert slide.body[0].level == 3
+
+    def test_legacy_two_column_becomes_nested_columns(self):
+        slide = coerce_slides([{
+            "slide_type": "two_column",
+            "left_heading": "L", "left_column": [{"text": "a"}],
+            "right_column": [{"text": "b"}],
+        }])[0]
+        assert slide.left.heading == "L"
+        assert slide.left.body[0].text == "a"
+        assert slide.right.heading is None
+        assert slide.right.body[0].text == "b"
+
+    def test_legacy_has_legend_false_becomes_none(self):
+        slide = coerce_slides([{
+            "slide_type": "chart", "chart_type": "pie",
+            "chart_data": {"categories": ["a"], "series": [{"name": "s", "values": [1]}]},
+            "has_legend": False,
+        }])[0]
+        assert slide.legend == "none"
+
+    def test_out_of_range_level_is_clamped_not_rejected(self):
+        """Phase 0 clamped these; the typed schema must not turn it into an error."""
+        slide = coerce_slides([{
+            "type": "content",
+            "body": [{"text": "a", "level": 9}, {"text": "b", "level": "2"},
+                     {"text": "c", "level": "deep"}],
+        }])[0]
+        assert [b.level for b in slide.body] == [5, 2, 1]
+
+
+# =============================================================================
+# Markdown bodies
+# =============================================================================
+
+class TestMarkdownBody:
+
+    def test_two_space_indent(self):
+        bullets = body_to_bullets("- one\n  - nested\n- two")
+        assert [(b.text, b.level) for b in bullets] == [
+            ("one", 1), ("nested", 2), ("two", 1)
+        ]
+
+    def test_four_space_and_tab_indent_agree(self):
+        four = body_to_bullets("- a\n    - b\n        - c")
+        tabs = body_to_bullets("- a\n\t- b\n\t\t- c")
+        assert [b.level for b in four] == [1, 2, 3]
+        assert [b.level for b in tabs] == [1, 2, 3]
+
+    @pytest.mark.parametrize("marker", ["-", "*", "+"])
+    def test_all_bullet_markers(self, marker):
+        assert body_to_bullets(f"{marker} item")[0].text == "item"
+
+    def test_line_without_marker_is_top_level(self):
+        bullets = body_to_bullets("Plain line\n- bullet")
+        assert [(b.text, b.level) for b in bullets] == [("Plain line", 1), ("bullet", 1)]
+
+    def test_blank_lines_are_skipped(self):
+        assert len(body_to_bullets("- a\n\n\n- b")) == 2
+
+    def test_explicit_bullets_pass_through(self):
+        bullets = body_to_bullets([Bullet(text="x", level=2)])
+        assert bullets[0].level == 2
+
+    def test_markdown_body_renders(self):
+        pres = build([{"type": "content", "title": "C", "body": "- top\n  - child\n- next"}])
+        paragraphs = body_paragraphs(reload_presentation(pres).slides[0])
+        assert [(p.text, p.level) for p in paragraphs[:3]] == [
+            ("top", 0), ("child", 1), ("next", 0)
+        ]
+
+    def test_markdown_body_keeps_inline_formatting(self):
+        pres = build([{"type": "content", "title": "C", "body": "- Revenue **up 12%**"}])
+        runs = body_paragraphs(reload_presentation(pres).slides[0])[0].runs
+        assert any(run.font.bold and run.text == "up 12%" for run in runs)
+
+    def test_markdown_body_in_two_column(self):
+        pres = build([{
+            "type": "two_column", "title": "2c",
+            "left": {"heading": "L", "body": "- a\n  - a2"},
+            "right": {"body": "- b"},
+        }])
+        texts = [
+            shape.text_frame.text
+            for shape in reload_presentation(pres).slides[0].shapes
+            if shape.has_text_frame
+        ]
+        assert any("a2" in text for text in texts)
+        assert any("b" in text for text in texts)
+
+
+# =============================================================================
+# Charts
+# =============================================================================
+
+class TestCharts:
+
+    def test_scatter_builds(self):
+        """The chart type that could never build before."""
+        pres = build([{
+            "type": "scatter", "title": "XY",
+            "series": [{"name": "trial", "points": [[1, 2.5], [2, 3.5], [3, 9]]}],
+            "x_title": "dose", "y_title": "response",
+        }])
+        slide = reload_presentation(pres).slides[0]
+        charts = [shape.chart for shape in slide.shapes if shape.has_chart]
+        assert len(charts) == 1
+        assert len(charts[0].plots[0].series) == 1
+
+    def test_scatter_with_multiple_series(self):
+        pres = build([{
+            "type": "scatter", "title": "XY",
+            "series": [
+                {"name": "a", "points": [[1, 1], [2, 2]]},
+                {"name": "b", "points": [[1, 3], [2, 4]]},
+            ],
+        }])
+        chart = [s.chart for s in reload_presentation(pres).slides[0].shapes if s.has_chart][0]
+        assert len(chart.plots[0].series) == 2
+
+    def test_data_labels_and_number_format(self):
+        pres = build([{
+            "type": "chart", "title": "C", "chart_type": "column",
+            "categories": ["a", "b"], "series": [{"name": "s", "values": [1000, 2000]}],
+            "data_labels": True, "number_format": "#,##0",
+        }])
+        chart = [s.chart for s in reload_presentation(pres).slides[0].shapes if s.has_chart][0]
+        plot = chart.plots[0]
+        assert plot.has_data_labels
+        assert plot.data_labels.number_format == "#,##0"
+
+    def test_legend_none_hides_it(self):
+        pres = build([{
+            "type": "chart", "title": "C", "chart_type": "pie",
+            "categories": ["a"], "series": [{"name": "s", "values": [1]}],
+            "legend": "none",
+        }])
+        chart = [s.chart for s in reload_presentation(pres).slides[0].shapes if s.has_chart][0]
+        assert chart.has_legend is False
+
+    def test_axis_titles(self):
+        pres = build([{
+            "type": "chart", "title": "C", "chart_type": "column",
+            "categories": ["a"], "series": [{"name": "s", "values": [1]}],
+            "x_title": "Quarter", "y_title": "Revenue",
+        }])
+        chart = [s.chart for s in reload_presentation(pres).slides[0].shapes if s.has_chart][0]
+        assert chart.value_axis.axis_title.text_frame.text == "Revenue"
+        assert chart.category_axis.axis_title.text_frame.text == "Quarter"
+
+    def test_axis_title_on_pie_is_ignored_not_fatal(self):
+        """A pie has no axes; asking for a title should not fail the deck."""
+        pres = build([{
+            "type": "chart", "title": "C", "chart_type": "pie",
+            "categories": ["a"], "series": [{"name": "s", "values": [1]}],
+            "y_title": "Revenue",
+        }])
+        assert len(reload_presentation(pres).slides) == 1
+
+    def test_chart_title(self):
+        pres = build([{
+            "type": "chart", "title": "Slide", "chart_type": "column",
+            "categories": ["a"], "series": [{"name": "s", "values": [1]}],
+            "chart_title": "Inside the chart",
+        }])
+        chart = [s.chart for s in reload_presentation(pres).slides[0].shapes if s.has_chart][0]
+        assert chart.chart_title.text_frame.text == "Inside the chart"
+
+    def test_series_length_mismatch_warns(self):
+        pres = build([{
+            "type": "chart", "title": "C", "chart_type": "column",
+            "categories": ["a", "b", "c"], "series": [{"name": "short", "values": [1]}],
+        }])
+        assert any("short" in w and "categories" in w for w in pres.warnings)
+
+    def test_null_value_is_allowed(self):
+        pres = build([{
+            "type": "chart", "title": "C", "chart_type": "line",
+            "categories": ["a", "b", "c"],
+            "series": [{"name": "s", "values": [1, None, 3]}],
+        }])
+        assert len(reload_presentation(pres).slides) == 1
+
+
+# =============================================================================
+# Images
+# =============================================================================
+
+class TestInlineImages:
+
+    def test_is_data_uri(self):
+        assert is_data_uri(PNG_DATA_URI)
+        assert not is_data_uri("https://example.com/a.png")
+
+    def test_decode_data_uri(self):
+        stream, ext = decode_data_uri(PNG_DATA_URI)
+        assert ext == "png"
+        assert stream.getvalue() == PNG_1PX
+
+    def test_inline_image_is_placed(self):
+        """No network, no public URL: the bytes are already in the payload."""
+        pres = build([{"type": "image", "title": "Chart", "source": PNG_DATA_URI}])
+        slide = reload_presentation(pres).slides[0]
+        assert any(shape.shape_type == 13 for shape in slide.shapes)  # PICTURE
+        assert pres.warnings == []
+
+    def test_inline_image_with_caption(self):
+        pres = build([{
+            "type": "image", "title": "Chart", "source": PNG_DATA_URI, "caption": "Fig 1",
+        }])
+        texts = [
+            shape.text_frame.text
+            for shape in reload_presentation(pres).slides[0].shapes
+            if shape.has_text_frame
+        ]
+        assert any("Fig 1" in text for text in texts)
+
+    def test_non_image_data_uri_is_rejected(self):
+        with pytest.raises(ImageValidationError, match="Invalid image type"):
+            decode_data_uri("data:text/html;base64," + base64.b64encode(b"<h1>x</h1>").decode())
+
+    def test_non_base64_data_uri_is_rejected(self):
+        with pytest.raises(ImageValidationError, match="base64"):
+            decode_data_uri("data:image/png,notbase64")
+
+    def test_corrupt_base64_is_rejected(self):
+        with pytest.raises(ImageValidationError, match="decode"):
+            decode_data_uri("data:image/png;base64,!!!!not-base64!!!!")
+
+    def test_image_slide_without_a_source_is_rejected(self):
+        """It used to build an empty slide and report success."""
+        with pytest.raises(ValueError) as excinfo:
+            coerce_slides([{"type": "image", "title": "No picture"}])
+        assert "source" in str(excinfo.value)
+
+    def test_failed_image_warns_instead_of_silently_placeholdering(self):
+        pres = build([{"type": "image", "title": "X", "source": "data:image/png;base64,!!!"}])
+        assert any("image could not be loaded" in w for w in pres.warnings)
+
+
+# =============================================================================
+# Warnings channel
+# =============================================================================
+
+class TestWarnings:
+
+    def test_clean_deck_has_no_warnings(self):
+        pres = build([
+            {"type": "title", "title": "T"},
+            {"type": "content", "title": "C", "body": "- short"},
+        ])
+        assert pres.warnings == []
+
+    def test_layout_override_is_reported_as_ignored(self):
+        """Accepted by the schema, not yet honoured — say so rather than drop it."""
+        pres = build([{"type": "content", "title": "C", "body": "- a", "layout": "Brand Body"}])
+        assert any("Brand Body" in w and "ignored" in w for w in pres.warnings)
+
+    def test_overfull_body_warns(self):
+        long_bullets = [{"text": "A fairly long bullet line that will wrap once or twice " * 3}
+                        for _ in range(24)]
+        pres = build([{"type": "content", "title": "Too much", "body": long_bullets}])
+        assert any("shrunk to fit" in w for w in pres.warnings)
+
+    def test_tall_table_warns_and_shrinks(self):
+        rows = [["Col A", "Col B"]] + [[f"row {i}", str(i)] for i in range(40)]
+        pres = build([{"type": "table", "title": "Big", "rows": rows}])
+        assert any("table" in w for w in pres.warnings)
+
+    def test_empty_table_warns(self):
+        pres = build([{"type": "table", "title": "Empty", "rows": []}])
+        assert any("no rows" in w for w in pres.warnings)
+
+    def test_warnings_name_the_slide_index(self):
+        pres = build([
+            {"type": "title", "title": "T"},
+            {"type": "image", "title": "X", "source": "data:image/png;base64,!!!"},
+        ])
+        assert any(w.startswith("slide 1:") for w in pres.warnings)
+
+
+# =============================================================================
+# Autofit and table sizing
+# =============================================================================
+
+class TestFit:
+
+    def test_estimate_grows_with_text(self):
+        small = estimate_text_fill([Bullet(text="short")], Emu(6000000), Emu(3000000))
+        large = estimate_text_fill([Bullet(text="x" * 4000)], Emu(6000000), Emu(3000000))
+        assert large > small
+        assert small < 1.0 < large
+
+    def test_autofit_element_is_written(self):
+        pres = build([{
+            "type": "content", "title": "C",
+            "body": [{"text": "a line that wraps " * 30} for _ in range(20)],
+        }])
+        slide = reload_presentation(pres).slides[0]
+        body = [s for s in slide.shapes if s.is_placeholder and s.placeholder_format.idx == 1][0]
+        bodyPr = body.text_frame._txBody.find(qn('a:bodyPr'))
+        autofit = bodyPr.find(qn('a:normAutofit'))
+        assert autofit is not None
+        assert int(autofit.get('fontScale')) <= 100000
+
+    def test_table_font_shrinks_with_row_count(self):
+        tall = fit_table_font_size(40, Emu(4000000))
+        short = fit_table_font_size(4, Emu(4000000))
+        assert tall < short
+
+    def test_table_font_never_below_floor(self):
+        assert fit_table_font_size(500, Emu(4000000)) >= 9
+
+    def test_explicit_table_font_size_is_honoured(self):
+        rows = [["A", "B"]] + [[str(i), "x"] for i in range(30)]
+        pres = build([{"type": "table", "title": "T", "rows": rows, "font_size": 8}])
+        table = [s.table for s in reload_presentation(pres).slides[0].shapes if s.has_table][0]
+        assert table.cell(1, 0).text_frame.paragraphs[0].font.size.pt == 8
+
+
+# =============================================================================
+# Language
+# =============================================================================
+
+class TestLanguage:
+
+    def test_language_is_stamped_on_runs(self):
+        pres = build(
+            [{"type": "content", "title": "Nadpis", "body": "- Text s **tučným** slovem"}],
+            language="cs-CZ",
+        )
+        xml = reload_presentation(pres).slides[0].shapes[1]._element.xml
+        assert 'lang="cs-CZ"' in xml
+
+    def test_language_reaches_table_cells(self):
+        pres = build(
+            [{"type": "table", "title": "T", "rows": [["Sloupec"], ["Hodnota"]]}],
+            language="cs-CZ",
+        )
+        table = [s for s in reload_presentation(pres).slides[0].shapes if s.has_table][0]
+        assert 'lang="cs-CZ"' in table._element.xml
+
+    def test_no_language_leaves_runs_untouched(self):
+        pres = build([{"type": "content", "title": "T", "body": "- a"}])
+        xml = reload_presentation(pres).slides[0].shapes[1]._element.xml
+        assert 'lang=' not in xml
+
+
+# =============================================================================
+# Buffer contract
+# =============================================================================
+
+def test_buffer_function_returns_warnings():
+    from pptx_tools import _create_presentation_buffer
+
+    buffer, warnings = _create_presentation_buffer(
+        [{"type": "content", "title": "C", "body": "- a", "layout": "Nope"}], "16:9"
+    )
+    assert isinstance(buffer, io.BytesIO)
+    assert any("Nope" in w for w in warnings)
+    assert len(PptxReader(buffer).slides) == 1


### PR DESCRIPTION
Closes #98. Part of #96. Follows #101 (Phase 0, merged).

| Stack | Issue | Status |
|---|---|---|
| Phase 0 — stop the bleeding | #97 | merged in #101 |
| **Phase 1 — typed slide schema** | #98 | **this PR** |
| Phase 2 — template registry | #99 | next, branches off master after this |
| Phase 3 — new slide types, admin UI | #100 | after Phase 2 |

## The problem

`slides` was `List[dict]`, and the entire contract lived in a paragraph of prose. FastMCP rendered it as `items: {type: object, additionalProperties: true}`, so nothing was validated: `text` instead of `slide_text` produced an empty slide and a success response.

Each slide type is now a Pydantic model joined by a discriminated union. The client gets a real JSON schema — `oneOf` plus a `discriminator`, 13 `$defs` — and bad input is rejected with a path before any rendering happens:

```
ValidationError for call[create_powerpoint_presentation] slides.0
  Input tag 'bullets' found using 'type' does not match any of the expected tags: 'title', 'section', 'content', …
```

## Strict structure, loose values

`extra="forbid"` turns a misspelled key into an error instead of a silently missing element. Values stay forgiving, because they come from a model: table cells take `str | int | float | null`, bullet levels clamp rather than fail (preserving Phase 0 behaviour), colours take `#RRGGBB`, `RRGGBB` or a theme name.

`body` accepts a markdown bullet string as well as explicit bullets, which is the single biggest reduction in payload size:

```jsonc
// before
"slide_text": [
  {"text": "Revenue **up 12%**", "indentation_level": 1},
  {"text": "EMEA +18%", "indentation_level": 2},
  {"text": "APAC +4%", "indentation_level": 2}
]
// after
"body": "- Revenue **up 12%**\n  - EMEA +18%\n  - APAC +4%"
```

The indent unit is inferred from the distinct widths present, so two spaces, four spaces and tabs all nest correctly without the caller declaring which they used.

## Backwards compatible

Every previous key name is still accepted and mapped onto the current one by a before-validator that runs *ahead of* union discrimination — it has to, since discrimination reads `type` and would otherwise reject every old-style slide outright. Deprecated keys are noted in the log.

The 45 pre-existing tests pass unchanged and now exercise that shim as a side effect, which is the strongest evidence the mapping is right.

## What the schema unlocked

- **`scatter` is a real slide type**, built with `XyChartData` from `[x, y]` pairs. It was advertised as a `chart_type` for a long time and could never build.
- **Charts** gain data labels, number format, axis titles, an inner chart title, and a legend that can be switched off. A pie asked for an axis title no-ops instead of failing.
- **Images** accept an inline `data:` URI, so an image the caller already holds — one a user pasted into the conversation — can be placed without publishing it to a URL the server can reach first.
- **Theme colours.** A table header fill of `accent1` is written as `schemeClr`, so the deck follows the template's palette instead of a pinned literal.
- **`language`** stamps `lang` on every run, including table cells and speaker notes, so a Czech deck is not proof-read against the template's locale with every word underlined.

## Warnings channel

The builder collects what it had to work around, and the tool returns it alongside the file:

```json
{"file": "https://…/deck.pptx", "slide_count": 12,
 "warnings": ["slide 4: body text is about 1.9x the space available and will be shrunk to fit; consider splitting it across slides."]}
```

An image that would not load, body text shrunk to fit, a footer dropped because the layout has no footer placeholder, a `layout` name that is accepted but not yet honoured, a series whose length disagrees with its categories — all of these previously lived in the server log while the caller was told the deck was fine. A clean deck returns the bare URL string as before.

Overfull body text now gets `normAutofit` with an explicit `fontScale`, and a tall table gets a font size chosen from its row count, so neither runs off the slide. Both are estimates rather than real text measurement — documented as such in `constants.py`, since shipping a font-metrics dependency to drive a warning is not worth it — and both warn.

## One deliberate convention break

`_create_presentation_buffer` now returns `(buffer, warnings)` rather than a bare `BytesIO` like the other four `_create_*_buffer` helpers. That asymmetry is the price of the warnings channel; `AGENTS.md` records it so the next person is not surprised.

## Review follow-up (second commit)

The automated review found two real issues, both verified here by execution before acting:

- A legacy chart sending both `has_legend: false` **and** `legend_position` had the position popped and discarded without being recorded, so the deprecation log named one key while swallowing the other. Precedence is unchanged and deliberate — the old renderer tested `has_legend` first and never read the position, so the shim must do the same — but the discarded key is now logged.
- `add_scatter_to_slide` resolved a series name with `getattr(...) or ...`, which cannot tell "absent" from "present but falsy", so a legal empty-string name became `None`. Replaced with an explicit attribute-or-key read. Worth stating precisely: **the rendered output was unaffected**, since `add_series(None)` yields a series named `''` anyway. This was a latent trap rather than a live defect, fixed so the next caller of that exported helper does not have to rediscover it.

I declined one cosmetic suggestion — that the deprecation log omit a legacy key whose value lost to a new-style key. That log exists to surface prompts still using old spellings, so narrowing it to "seen and applied" would hide the case most worth knowing about.

## Verification

```
1085 passed, 5 deselected     # full suite, network excluded
5 passed                      # the network-marked tests, run separately
All checks passed!            # ruff
```

New `tests/test_pptx_schema.py`, 65 tests: discrimination and error paths, the legacy shim end to end (including contradictory and doubled keys), markdown body parsing across indent styles, scatter and chart options, inline images, the warnings channel, autofit and table sizing, language stamping.

I also moved one test out of the network-marked class. `test_image_slide_no_url` built an image slide with no source, which the schema now rejects; it needs no network, and the marker was hiding it from CI. It is now an explicit assertion that the case is rejected — that empty-slide-plus-success-response is exactly the failure this phase exists to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYtbUgysFugzG2h8dhnKU1