### PR TITLE
feat(pptx): Phase 3b — admin UI for PowerPoint templates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -608,6 +608,11 @@ restarting the server**.
 The file `config/pptx_templates.yaml` in this repository documents every option
 in full.
 
+You can also register and configure templates from the browser instead of
+writing YAML — see [Template Admin UI](#-template-admin-ui-optional). It reports
+each layout's detected role and previews a sample deck through the template
+before you save.
+
 </details>
 
 ### Dynamic Email Templates
@@ -787,8 +792,8 @@ Unknown style names fall back to the document default (with a logged warning) ra
 ## 🖥️ Template Admin UI (optional)
 
 Prefer clicking over editing YAML? Enable the built-in **template-admin UI** to
-create and manage dynamic **Word** and **email** templates from your browser —
-no YAML, no restart.
+create and manage dynamic **Word**, **email** and **PowerPoint** templates from
+your browser — no YAML, no restart.
 
 <details>
 <summary><strong>How to enable and use it</strong></summary>
@@ -824,10 +829,33 @@ http://localhost:8958/admin
   used this session), and a recent activity & error log (filterable to
   warnings/errors).
 
+**PowerPoint templates work differently.** A Word or email template is a
+fill-in-the-blanks document: it declares arguments and becomes an MCP tool of
+its own. A PowerPoint template is a *design* — slide master, layouts, theme
+fonts and palette — with no placeholders and no arguments. It does not become a
+tool; it becomes one more value you can pass as the `template` argument of
+`create_powerpoint_presentation`. So its page looks different:
+
+- **Upload** a `.pptx` or a `.potx` (a designer's template file is taken as
+  readily as a deck).
+- The UI reports the **slide size and aspect**, every **layout** with its
+  placeholders and the slide role auto-detected for it, and the **theme** fonts
+  and colours. It warns about the things that actually spoil a generated deck:
+  a role no layout covers (those slides fall back by position), layouts with no
+  footer placeholder, and sample slides left in the file.
+- **Override a layout per role** only where the automatic choice is wrong — the
+  dropdowns are populated with the template's real layout names.
+- Set **deck defaults** — footer text, language, slide numbers — applied
+  whenever a tool call does not set the same option.
+- **Preview** builds a real six-slide sample deck through the template, using
+  the layout choices on screen *including ones you have not saved yet*.
+- **Save** — the presentation tool can build on it immediately, no restart.
+
 **How it's stored:** the UI writes one file per template into
-`config/docx_templates.d/` or `config/email_templates.d/` (plus the asset into
-`custom_templates/`). Your hand-written master `config/*.yaml` files are never
-modified — UI templates are simply merged on top of them at load time.
+`config/docx_templates.d/`, `config/email_templates.d/` or
+`config/pptx_templates.d/` (plus the asset into `custom_templates/`). Your
+hand-written master `config/*.yaml` files are never modified — UI templates are
+simply merged on top of them at load time.
 
 > **Single-instance note:** live, no-restart registration assumes one server
 > instance owns the template files (the standard docker-compose setup). For a

--- a/admin/analysis.py
+++ b/admin/analysis.py
@@ -16,6 +16,7 @@ tested on its own.
 from __future__ import annotations
 
 import io
+import logging
 import re
 import tempfile
 from dataclasses import dataclass, field
@@ -28,6 +29,8 @@ from lxml import etree
 
 from docx_tools.dynamic_docx_tools import PLACEHOLDER_PATTERN
 from docx_tools.conditionals import parse_marker
+
+logger = logging.getLogger(__name__)
 
 # Styles the markdown renderer applies by name; warn when a template lacks them.
 REQUIRED_DOCX_STYLES = [
@@ -358,6 +361,17 @@ def _read_theme(presentation) -> tuple:
             sys_clr = node.find(pptx_qn("a:sysClr"))
             if sys_clr is not None and sys_clr.get("lastClr"):
                 colors[name] = f"#{sys_clr.get('lastClr').upper()}"
+                continue
+            # OOXML also permits scrgbClr, hslClr, prstClr and schemeClr here.
+            # Office writes only srgbClr and sysClr, so the others are not worth
+            # converting — but say so rather than dropping the entry in silence,
+            # which is the failure mode this whole reader was written to avoid.
+            if len(node):
+                logger.info(
+                    "[template-analysis] Theme colour %r uses <%s>, which is not "
+                    "one of srgbClr/sysClr; omitted from the reported palette.",
+                    name, etree.QName(node[0]).localname,
+                )
     return fonts, colors
 
 

--- a/admin/analysis.py
+++ b/admin/analysis.py
@@ -17,11 +17,14 @@ from __future__ import annotations
 
 import io
 import re
+import tempfile
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from docx import Document as DocxDocument
 from docx.oxml.ns import qn
+from lxml import etree
 
 from docx_tools.dynamic_docx_tools import PLACEHOLDER_PATTERN
 from docx_tools.conditionals import parse_marker
@@ -170,12 +173,244 @@ def analyze_html(data: bytes) -> Analysis:
     return analysis
 
 
-def analyze(kind: str, data: bytes) -> Analysis:
-    """Dispatch analysis by template *kind* (``docx`` or ``email``)."""
+# ---------------------------------------------------------------------------
+# PowerPoint
+# ---------------------------------------------------------------------------
+
+# The theme lives on a relationship from the slide master. Spelt out rather
+# than imported so this module keeps its light import surface.
+_THEME_RELTYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme"
+
+
+@dataclass
+class LayoutInfo:
+    """One slide layout, as the admin UI needs to show it."""
+    index: int
+    name: str
+    placeholders: List[str] = field(default_factory=list)
+    role: Optional[str] = None          # auto-detected role, None when unrecognised
+    has_footer: bool = False
+
+
+@dataclass
+class PptxAnalysis:
+    """Result of analysing a ``.pptx`` / ``.potx`` template.
+
+    Deliberately *not* an :class:`Analysis`. That type describes a parameterised
+    document — placeholders, conditionals, args to declare. A presentation
+    template has none of those: it is a design, and what an admin needs to see
+    is which layouts it offers and which slide roles those cover. The only
+    field the two share is ``warnings``, which is all the shared view code
+    touches.
+    """
+    kind: str = "pptx"
+    aspect: Optional[str] = None
+    slide_size: Optional[str] = None
+    layouts: List[LayoutInfo] = field(default_factory=list)
+    role_map: Dict[str, str] = field(default_factory=dict)   # role -> layout name
+    missing_roles: List[str] = field(default_factory=list)
+    theme_fonts: Dict[str, str] = field(default_factory=dict)
+    theme_colors: Dict[str, str] = field(default_factory=dict)
+    embedded_slides: int = 0
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def layout_names(self) -> List[str]:
+        """Layout names, for populating the role-override dropdowns."""
+        return [layout.name for layout in self.layouts]
+
+
+def _placeholder_label(placeholder) -> str:
+    """Human-readable placeholder type, e.g. ``TITLE`` or ``BODY``."""
+    try:
+        kind = placeholder.placeholder_format.type
+    except Exception:
+        return "UNKNOWN"
+    name = getattr(kind, "name", None)
+    return str(name or kind)
+
+
+def _theme_root(presentation):
+    """The parsed theme XML of the first slide master, or None.
+
+    python-pptx has no model class for a theme, so the relationship resolves to
+    a generic ``Part`` carrying only raw bytes — there is no ``_element`` to
+    read. Reaching for one returns None and yields an empty palette rather than
+    an error, so the blob is parsed here instead.
+    """
+    try:
+        master = presentation.slide_masters[0]
+    except (IndexError, AttributeError):
+        return None
+    try:
+        theme = master.part.part_related_by(_THEME_RELTYPE)
+    except (KeyError, AttributeError):
+        return None
+
+    blob = getattr(theme, "blob", None)
+    if not blob:
+        return None
+    try:
+        return etree.fromstring(blob)
+    except etree.XMLSyntaxError:
+        return None
+
+
+def analyze_pptx(data: bytes) -> PptxAnalysis:
+    """Analyse a PowerPoint template given its bytes.
+
+    Reports what actually decides how a generated deck looks: the slide size,
+    the layouts on offer with their placeholder signatures, which slide role
+    each layout is auto-detected as, and the theme's fonts and accent colours.
+
+    A ``.potx`` is accepted — it is opened through the same
+    :func:`pptx_tools.templates.open_template` the tool uses, which rewrites the
+    template content type in memory.
+    """
+    from pptx.util import Emu
+
+    from pptx_tools.layouts import ROLES, classify_layout
+    from pptx_tools.templates import aspect_of, open_template
+
+    analysis = PptxAnalysis()
+
+    # open_template takes a path, so the upload is staged to a temp file. The
+    # .potx branch keys off the content type rather than the name, so the
+    # suffix used here does not decide anything.
+    with tempfile.TemporaryDirectory() as tmp:
+        staged = Path(tmp) / "upload.pptx"
+        staged.write_bytes(data)
+        try:
+            presentation = open_template(staged)
+        except Exception as e:
+            analysis.warnings.append(f"Could not open as a PowerPoint template: {e}")
+            return analysis
+
+        analysis.aspect = aspect_of(presentation)
+        width = Emu(presentation.slide_width).inches
+        height = Emu(presentation.slide_height).inches
+        analysis.slide_size = f"{width:.2f} × {height:.2f} in"
+        analysis.embedded_slides = len(presentation.slides._sldIdLst)
+
+        seen_roles: Dict[str, str] = {}
+        for index, layout in enumerate(presentation.slide_layouts):
+            placeholders = [_placeholder_label(p) for p in layout.placeholders]
+            role = classify_layout(layout)
+            analysis.layouts.append(LayoutInfo(
+                index=index,
+                name=layout.name,
+                placeholders=placeholders,
+                role=role,
+                has_footer=any(label == "FOOTER" for label in placeholders),
+            ))
+            # First layout detected for a role is the one the resolver picks.
+            if role and role not in seen_roles:
+                seen_roles[role] = layout.name
+
+        analysis.role_map = seen_roles
+        analysis.missing_roles = [role for role in ROLES if role not in seen_roles]
+        analysis.theme_fonts, analysis.theme_colors = _read_theme(presentation)
+
+    _add_pptx_warnings(analysis)
+    return analysis
+
+
+def _read_theme(presentation) -> tuple:
+    """Return ``(fonts, colors)`` from the first slide master's theme."""
+    # python-pptx's namespace map, not python-docx's. Both happen to resolve
+    # the DrawingML "a:" prefix identically, but reading a PowerPoint theme
+    # through the Word nsmap is an accident waiting to be broken by either side.
+    from pptx.oxml.ns import qn as pptx_qn
+
+    fonts: Dict[str, str] = {}
+    colors: Dict[str, str] = {}
+    theme = _theme_root(presentation)
+    if theme is None:
+        return fonts, colors
+
+    scheme = theme.find(pptx_qn("a:themeElements"))
+    if scheme is None:
+        return fonts, colors
+
+    font_scheme = scheme.find(pptx_qn("a:fontScheme"))
+    if font_scheme is not None:
+        for tag, label in (("a:majorFont", "headings"), ("a:minorFont", "body")):
+            node = font_scheme.find(pptx_qn(tag))
+            latin = node.find(pptx_qn("a:latin")) if node is not None else None
+            typeface = latin.get("typeface") if latin is not None else None
+            if typeface:
+                fonts[label] = typeface
+
+    color_scheme = scheme.find(pptx_qn("a:clrScheme"))
+    if color_scheme is not None:
+        for name in ("dk1", "lt1", "dk2", "lt2",
+                     "accent1", "accent2", "accent3", "accent4", "accent5", "accent6",
+                     "hlink", "folHlink"):
+            node = color_scheme.find(pptx_qn(f"a:{name}"))
+            if node is None:
+                continue
+            srgb = node.find(pptx_qn("a:srgbClr"))
+            if srgb is not None and srgb.get("val"):
+                colors[name] = f"#{srgb.get('val').upper()}"
+                continue
+            # A system colour (windowText / window) carries its resolved value
+            # in lastClr; without this dk1/lt1 read as blank on Office themes.
+            sys_clr = node.find(pptx_qn("a:sysClr"))
+            if sys_clr is not None and sys_clr.get("lastClr"):
+                colors[name] = f"#{sys_clr.get('lastClr').upper()}"
+    return fonts, colors
+
+
+def _add_pptx_warnings(analysis: PptxAnalysis) -> None:
+    """Attach the warnings an admin can act on."""
+    if not analysis.layouts:
+        analysis.warnings.append("This template defines no slide layouts.")
+        return
+
+    # Roles that fall back by position when absent, which is what produces a
+    # deck laid out on the wrong layouts.
+    if analysis.missing_roles:
+        analysis.warnings.append(
+            "No layout was detected for: " + ", ".join(analysis.missing_roles) +
+            ". Slides needing those roles fall back by position — set an override "
+            "below, or ignore this if the template is not meant to cover them."
+        )
+
+    without_footer = [layout.name for layout in analysis.layouts if not layout.has_footer]
+    if without_footer and len(without_footer) < len(analysis.layouts):
+        analysis.warnings.append(
+            f"No footer placeholder on {len(without_footer)} of {len(analysis.layouts)} "
+            "layouts; footer text and slide numbers will not show on those slides."
+        )
+    elif len(without_footer) == len(analysis.layouts):
+        analysis.warnings.append(
+            "No layout has a footer placeholder, so footer text and slide numbers "
+            "will not appear anywhere in a generated deck."
+        )
+
+    if analysis.embedded_slides:
+        analysis.warnings.append(
+            f"The file contains {analysis.embedded_slides} slide(s) of its own. "
+            "They are stripped from generated decks by default (strip_slides)."
+        )
+
+    unrecognised = [layout.name for layout in analysis.layouts if layout.role is None]
+    if unrecognised:
+        analysis.warnings.append(
+            f"{len(unrecognised)} layout(s) match no known role and can only be used "
+            "by naming them explicitly: " + ", ".join(unrecognised[:6])
+            + ("…" if len(unrecognised) > 6 else "")
+        )
+
+
+def analyze(kind: str, data: bytes):
+    """Dispatch analysis by template *kind* (``docx``, ``email`` or ``pptx``)."""
     if kind == "docx":
         return analyze_docx(data)
     if kind == "email":
         return analyze_html(data)
+    if kind == "pptx":
+        return analyze_pptx(data)
     raise ValueError(f"Unknown template kind: {kind!r}")
 
 

--- a/admin/app.py
+++ b/admin/app.py
@@ -1,14 +1,24 @@
-"""FastHTML admin UI for managing dynamic docx/email templates.
+"""FastHTML admin UI for managing dynamic docx / email / pptx templates.
 
 Mounted in the same ASGI process as the FastMCP server (see
-:func:`build_combined_app`) so that saving a template registers/updates its MCP
-tool immediately — no restart. The UI is gated by a single shared password
-(:mod:`admin.auth`) and persists templates through :class:`admin.store.TemplateStore`.
+:func:`build_combined_app`) so that saving a template takes effect immediately —
+no restart. The UI is gated by a single shared password (:mod:`admin.auth`) and
+persists templates through :class:`admin.store.TemplateStore`.
 
 Authoring model (chosen with the maintainer): the user uploads a real ``.docx``
 (or email ``.html``); the UI auto-detects placeholders/conditionals
 (:mod:`admin.analysis`), pre-builds the argument form, and previews
 (:mod:`admin.preview`) without ever hitting the upload backend.
+
+PowerPoint is the odd one out and the views branch on it in a few places. A
+docx or email template is a parameterised document that becomes an MCP tool of
+its own, so it has arguments to declare and "live" means the tool is
+registered. A pptx template is a *design* — layouts, theme, aspect — with no
+arguments at all; it becomes one more value for the ``template`` argument of
+the single ``create_powerpoint_presentation`` tool, and "live" means the
+template registry has re-read it. Its form offers layout roles and deck
+defaults where the others offer arguments, and its preview builds a fixed
+sample deck instead of substituting values.
 """
 from __future__ import annotations
 
@@ -16,6 +26,7 @@ import hashlib
 import json
 import logging
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import metrics
@@ -30,16 +41,21 @@ from starlette.routing import Mount
 
 from config import Config
 from admin import auth
-from admin.analysis import analyze, reconcile, Analysis
-from admin.preview import sample_values, render_docx_preview, render_email_preview
-from admin.store import FileTemplateStore, KIND_DOCX, KIND_EMAIL, TemplateStoreError, validate_name
+from admin.analysis import analyze, reconcile, Analysis, PptxAnalysis
+from admin.preview import (
+    sample_values, render_docx_preview, render_email_preview, render_pptx_preview,
+)
+from admin.store import (
+    FileTemplateStore, KIND_DOCX, KIND_EMAIL, KIND_PPTX,
+    TemplateStoreError, kind_meta, validate_name,
+)
 from template_registry import gather_specs
 
 logger = logging.getLogger(__name__)
 
-KINDS = (KIND_DOCX, KIND_EMAIL)
-_KIND_LABEL = {KIND_DOCX: "Word", KIND_EMAIL: "Email"}
-_KIND_ICON = {KIND_DOCX: "📝", KIND_EMAIL: "✉️"}
+KINDS = (KIND_DOCX, KIND_EMAIL, KIND_PPTX)
+_KIND_LABEL = {KIND_DOCX: "Word", KIND_EMAIL: "Email", KIND_PPTX: "PowerPoint"}
+_KIND_ICON = {KIND_DOCX: "📝", KIND_EMAIL: "✉️", KIND_PPTX: "📊"}
 _ARG_TYPES = ["string", "int", "float", "bool", "list"]
 # Style-mapping keys surfaced in the UI (subset of the full recognised set).
 _STYLE_KEYS = ["heading_1", "list_number", "list_bullet", "quote", "table"]
@@ -123,6 +139,14 @@ th{font-size:.78rem;text-transform:uppercase;letter-spacing:.03em;color:var(--mu
 .flash-warn{background:var(--warn-bg);border-color:#fde68a;color:#854d0e}
 .flash-err{background:var(--err-bg);border-color:#fecaca;color:#991b1b}
 .empty{text-align:center;padding:2rem 1rem;color:var(--muted)}
+/* PowerPoint template views */
+.role-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:0 1rem}
+.facts .field{margin-bottom:.6rem}
+.warn-text{color:var(--warn)}
+.swatch-wrap{display:inline-flex;align-items:center;gap:.35rem;margin:.15rem .6rem .15rem 0}
+.swatch{display:inline-block;width:14px;height:14px;border-radius:3px;border:1px solid var(--line)}
+.swatch-label{font-size:.78rem;color:var(--muted);font-family:ui-monospace,Menlo,monospace}
+.field label input[type=checkbox]{width:auto;margin-right:.4rem;vertical-align:-2px}
 details{margin:1rem 0;border:1px solid var(--line);border-radius:8px;padding:.5rem .85rem}
 summary{cursor:pointer;font-weight:600}
 .login-wrap{max-width:380px;margin:8vh auto}
@@ -184,7 +208,18 @@ class AdminContext:
 
     # -- live MCP tool registration ----------------------------------------
 
+    # A docx or email template *is* an MCP tool, so saving one registers a tool.
+    # A PowerPoint template is not: there is a single
+    # ``create_powerpoint_presentation`` tool and a template is one more value
+    # for its ``template`` argument. "Going live" therefore means the registry
+    # re-reads the spec directory, which is what clear_cache forces. The
+    # registry already notices the change on its own via a directory
+    # fingerprint; dropping the cache here just makes it immediate rather than
+    # on the next call that happens to look.
+
     def register(self, kind: str, spec: Dict[str, Any]) -> bool:
+        if kind == KIND_PPTX:
+            return self._refresh_pptx_registry(spec.get("name"))
         if kind == KIND_DOCX:
             from docx_tools.dynamic_docx_tools import register_docx_template
             return register_docx_template(self.mcp, spec, self.global_style_mapping)
@@ -192,6 +227,10 @@ class AdminContext:
         return register_email_template(self.mcp, spec)
 
     def unregister(self, kind: str, name: str) -> bool:
+        if kind == KIND_PPTX:
+            from pptx_tools.templates import clear_cache
+            clear_cache()
+            return True
         if kind == KIND_DOCX:
             from docx_tools.dynamic_docx_tools import unregister_docx_template
             return unregister_docx_template(self.mcp, name)
@@ -199,11 +238,35 @@ class AdminContext:
         return unregister_email_template(self.mcp, name)
 
     def live_names(self, kind: str) -> List[str]:
+        if kind == KIND_PPTX:
+            from pptx_tools.templates import template_names
+            try:
+                return template_names()
+            except Exception:
+                logger.exception("[admin] Could not read the pptx template registry")
+                return []
         if kind == KIND_DOCX:
             from docx_tools.dynamic_docx_tools import registered_docx_template_names
             return registered_docx_template_names()
         from email_tools.dynamic_email_tools import registered_email_template_names
         return registered_email_template_names()
+
+    @staticmethod
+    def _refresh_pptx_registry(name: Optional[str]) -> bool:
+        """Reload the pptx registry and report whether *name* is now in it.
+
+        Returning False here means the saved spec did not come back out of the
+        registry — almost always because its file is missing from the template
+        directories — and the admin is told so rather than being shown a
+        success message for a template the tool cannot use.
+        """
+        from pptx_tools.templates import clear_cache, template_names
+        clear_cache()
+        try:
+            return name in template_names()
+        except Exception:
+            logger.exception("[admin] Could not reload the pptx template registry")
+            return False
 
 
 # ---------------------------------------------------------------------------
@@ -262,8 +325,63 @@ def _parse_style_mapping(form) -> Dict[str, str]:
     return mapping
 
 
+def _checked(form, field: str) -> bool:
+    """True when a checkbox was submitted ticked.
+
+    An unticked HTML checkbox sends nothing at all, so absence has to mean
+    False rather than "unset".
+    """
+    return (form.get(field) or "").lower() in ("1", "true", "yes", "on")
+
+
+def _build_pptx_spec(form) -> Dict[str, Any]:
+    """Assemble a PowerPoint template spec from the submitted edit form.
+
+    Nothing like the docx/email spec: no ``args``, because a presentation
+    template takes no arguments. What it carries instead is how the deck should
+    be laid out — which layout plays each role, and the deck-wide defaults.
+    """
+    from pptx_tools.layouts import ROLES
+
+    name = validate_name((form.get("name") or "").strip())
+    spec: Dict[str, Any] = {
+        "name": name,
+        "description": (form.get("description") or "").strip(),
+        "pptx_path": (form.get("asset_filename") or "").strip(),
+    }
+    if _checked(form, "is_default"):
+        spec["default"] = True
+    # Only write strip_slides when it departs from the default, so a spec file
+    # stays as small as what the admin actually chose.
+    if not _checked(form, "strip_slides"):
+        spec["strip_slides"] = False
+
+    layouts = {
+        role: (form.get(f"layout_{role}") or "").strip()
+        for role in ROLES
+        if (form.get(f"layout_{role}") or "").strip()
+    }
+    if layouts:
+        spec["layouts"] = layouts
+
+    defaults: Dict[str, Any] = {}
+    footer = (form.get("default_footer_text") or "").strip()
+    if footer:
+        defaults["footer_text"] = footer
+    language = (form.get("default_language") or "").strip()
+    if language:
+        defaults["language"] = language
+    if _checked(form, "default_slide_numbers"):
+        defaults["show_slide_numbers"] = True
+    if defaults:
+        spec["defaults"] = defaults
+    return spec
+
+
 def _build_spec(kind: str, form) -> Dict[str, Any]:
     """Assemble a template spec dict from the submitted edit form."""
+    if kind == KIND_PPTX:
+        return _build_pptx_spec(form)
     name = validate_name((form.get("name") or "").strip())
     asset_filename = (form.get("asset_filename") or "").strip()
     description = (form.get("description") or "").strip()
@@ -282,11 +400,17 @@ def _build_spec(kind: str, form) -> Dict[str, Any]:
 
 
 def _path_key(kind: str) -> str:
-    return "docx_path" if kind == KIND_DOCX else "html_path"
+    return kind_meta(kind)["path_key"]
 
 
 def _asset_ext(kind: str) -> str:
-    return ".docx" if kind == KIND_DOCX else ".html"
+    """The canonical extension, used when deriving a filename from the name."""
+    return kind_meta(kind)["asset_ext"]
+
+
+def _accept_exts(kind: str) -> str:
+    """Every extension the upload field accepts, as an HTML accept list."""
+    return ",".join(kind_meta(kind)["asset_exts"])
 
 
 # ---------------------------------------------------------------------------
@@ -329,13 +453,20 @@ def _template_table(ctx: AdminContext, kind: str, csrf: str = ""):
     managed_names = {s.get("name") for s in managed}
     live = set(ctx.live_names(kind))
 
+    # "Args" is meaningless for a presentation template, which declares none;
+    # what distinguishes one there is whether it is the default.
+    detail_header = "Default" if kind == KIND_PPTX else "Args"
+
     rows = []
     for spec in managed:
         name = spec.get("name")
-        nargs = len(spec.get("args") or [])
+        if kind == KIND_PPTX:
+            detail = "★ default" if spec.get("default") else "—"
+        else:
+            detail = str(len(spec.get("args") or []))
         rows.append(Tr(
             Td(A(name, href=ctx.u(f"/{kind}/{name}/edit"))),
-            Td(str(nargs)),
+            Td(detail),
             Td(_status_badge(name in live)),
             Td(Div(
                 A("Edit", href=ctx.u(f"/{kind}/{name}/edit"), cls="btn btn-secondary btn-sm"),
@@ -363,7 +494,7 @@ def _template_table(ctx: AdminContext, kind: str, csrf: str = ""):
             cls="empty",
         )
     return Table(
-        Thead(Tr(Th("Name"), Th("Args"), Th("Status"), Th("Actions"))),
+        Thead(Tr(Th("Name"), Th(detail_header), Th("Status"), Th("Actions"))),
         Tbody(*rows),
         cls="tpl-table",
     )
@@ -423,7 +554,9 @@ def _style_mapping_block(analysis: Optional[Analysis], spec: Dict[str, Any]):
     )
 
 
-def _analysis_report(analysis: Analysis, spec: Dict[str, Any]):
+def _analysis_report(analysis, spec: Dict[str, Any]):
+    if isinstance(analysis, PptxAnalysis):
+        return _pptx_analysis_report(analysis)
     rec = reconcile(analysis, spec.get("args") or [])
     cond_set = set(analysis.conditionals)
     items = [
@@ -449,8 +582,177 @@ def _analysis_report(analysis: Analysis, spec: Dict[str, Any]):
                *[i for i in items if i is not None], cls="card")
 
 
+def _swatch(name: str, value: str):
+    """One theme colour, shown rather than described."""
+    return Span(
+        Span(cls="swatch", style=f"background:{value}"),
+        Span(f"{name} {value}", cls="swatch-label"),
+        cls="swatch-wrap", title=f"{name}: {value}",
+    )
+
+
+def _pptx_analysis_report(analysis: PptxAnalysis):
+    """What we found in a PowerPoint template: size, layouts, roles, theme."""
+    rows = []
+    for layout in analysis.layouts:
+        rows.append(Tr(
+            Td(layout.name),
+            Td(Span(layout.role, cls="chip") if layout.role
+               else Span("name it explicitly", cls="muted")),
+            Td(_chips(layout.placeholders)),
+            Td("—" if layout.has_footer else Span("no footer", cls="muted")),
+        ))
+
+    facts = Div(
+        Div(Label("Slide size"),
+            Span(f"{analysis.slide_size} ({analysis.aspect})" if analysis.slide_size
+                 else "unknown"), cls="field"),
+        Div(Label("Theme fonts"),
+            Span(", ".join(f"{k}: {v}" for k, v in analysis.theme_fonts.items())
+                 or "not declared", cls="muted" if not analysis.theme_fonts else ""),
+            cls="field"),
+        Div(Label("Theme colours"),
+            Span(*[_swatch(k, v) for k, v in analysis.theme_colors.items()])
+            if analysis.theme_colors else Span("not declared", cls="muted"),
+            cls="field"),
+        cls="facts",
+    )
+
+    items = [H3("What we found in the template"), facts]
+    for w in analysis.warnings:
+        items.append(_flash("⚠ " + w, "warn"))
+    if rows:
+        items.append(Table(
+            Thead(Tr(Th("Layout"), Th("Detected role"), Th("Placeholders"), Th("Footer"))),
+            Tbody(*rows), cls="tpl-table",
+        ))
+    return Div(*items, cls="card")
+
+
+def _pptx_edit_form(ctx: AdminContext, spec: Dict[str, Any],
+                    analysis: Optional[PptxAnalysis], is_new: bool, csrf: str = ""):
+    """The PowerPoint template form.
+
+    Deliberately not the argument editor. A presentation template declares no
+    arguments; what an admin needs to control is which layout plays each slide
+    role, and the deck-wide defaults.
+    """
+    from pptx_tools.layouts import ROLES
+
+    kind = KIND_PPTX
+    asset_filename = spec.get("pptx_path", "")
+    configured = spec.get("layouts") or {}
+    defaults = spec.get("defaults") or {}
+    detected = analysis.role_map if analysis else {}
+    layout_names = analysis.layout_names if analysis else []
+
+    name_field = (
+        Div(Label("Template name"),
+            Input(name="name", value=spec.get("name", ""), required=True,
+                  placeholder="e.g. corporate_16_9"),
+            P("Letters, digits and underscores. This is the value passed as "
+              "the 'template' argument when generating a deck.", cls="muted"),
+            cls="field")
+        if is_new else
+        Div(Label("Template name"), Input(value=spec.get("name", ""), disabled=True), cls="field")
+    )
+
+    details_card = Div(
+        H3("Template details"),
+        name_field,
+        Div(Label("Description"),
+            Textarea(spec.get("description", ""), name="description", rows="3",
+                     placeholder="When should the AI reach for this deck? "
+                                 "e.g. 'Brand deck, widescreen. Use for client-facing work.'"),
+            P("This is what the AI sees when choosing between templates.", cls="muted"),
+            cls="field"),
+        Div(Label(Input(name="is_default", type="checkbox", value="1",
+                        checked=bool(spec.get("default"))),
+                  " Use this template when none is named"), cls="field"),
+        Div(Label(Input(name="strip_slides", type="checkbox", value="1",
+                        checked=bool(spec.get("strip_slides", True))),
+                  " Drop any slides the template file itself contains"),
+            P("Sample slides a designer left in the file never belong in generated "
+              "output. Leave this on unless you know otherwise.", cls="muted"),
+            cls="field"),
+        cls="card",
+    )
+
+    # One dropdown per role, populated from the template's real layout names.
+    role_fields = []
+    for role in ROLES:
+        current = configured.get(role, "")
+        auto = detected.get(role)
+        auto_label = f"auto-detected: {auto}" if auto else "not detected"
+        opts = [Option(f"({auto_label})", value="", selected=not current)]
+        opts += [Option(n, value=n, selected=(n == current)) for n in layout_names]
+        role_fields.append(Div(
+            Label(role),
+            Select(*opts, name=f"layout_{role}"),
+            None if auto else P("No layout matches this role — slides needing it fall "
+                                "back by position unless you pick one.",
+                                cls="muted warn-text"),
+            cls="field",
+        ))
+
+    layouts_card = Div(
+        H3("Layout for each slide role"),
+        P("Layouts are matched automatically by their placeholders, so most templates "
+          "need nothing here. Override a role only when the automatic choice is wrong, "
+          "or when it says 'not detected'.", cls="muted"),
+        Div(*role_fields, cls="role-grid"),
+        cls="card",
+    )
+
+    defaults_card = Div(
+        H3("Deck defaults"),
+        P("Applied when the tool call does not set the same option.", cls="muted"),
+        Div(Label("Footer text"),
+            Input(name="default_footer_text", value=defaults.get("footer_text", "") or "",
+                  placeholder="e.g. ACME s.r.o. · Confidential"),
+            cls="field"),
+        Div(Label("Language"),
+            Input(name="default_language", value=defaults.get("language", "") or "",
+                  placeholder="e.g. cs-CZ"),
+            P("BCP-47 tag stamped on every text run, so the deck is proof-read in "
+              "the right language.", cls="muted"),
+            cls="field"),
+        Div(Label(Input(name="default_slide_numbers", type="checkbox", value="1",
+                        checked=bool(defaults.get("show_slide_numbers"))),
+                  " Show slide numbers"), cls="field"),
+        cls="card",
+    )
+
+    return Form(
+        _csrf_input(csrf),
+        Hidden(name="kind", value=kind),
+        Hidden(name="asset_filename", value=asset_filename),
+        Hidden(name="name", value=spec.get("name", "")) if not is_new else None,
+        details_card,
+        layouts_card,
+        defaults_card,
+        Div(
+            Div(
+                Button("Save & make live", type="submit", cls="btn btn-primary"),
+                Button("Preview sample deck", type="submit",
+                       formaction=ctx.u(f"/{kind}/preview"),
+                       formtarget="_blank", cls="btn btn-secondary"),
+                A("Cancel", href=ctx.u("/"), cls="btn"),
+                cls="actions",
+            ),
+            P("Preview builds a six-slide sample deck on this template, using the "
+              "layout choices above — including ones you have not saved yet.",
+              cls="muted"),
+            cls="card",
+        ),
+        action=ctx.u(f"/{kind}/save"), method="post",
+    )
+
+
 def _edit_form(ctx: AdminContext, kind: str, spec: Dict[str, Any],
                analysis: Optional[Analysis], is_new: bool, csrf: str = ""):
+    if kind == KIND_PPTX:
+        return _pptx_edit_form(ctx, spec, analysis, is_new, csrf)
     asset_filename = spec.get(_path_key(kind), "")
     annotations = spec.get("annotations") or {}
     cond_set = set(analysis.conditionals) if analysis else set()
@@ -651,19 +953,24 @@ def _new_page(ctx: AdminContext, kind: str, csrf: str = "", error: str = None):
         Div(
             Form(
                 _csrf_input(csrf),
-                Div(Label("Tool name"),
-                    Input(name="name", required=True, placeholder="e.g. formal_letter"),
-                    P("Letters, digits and underscores — this is what the AI calls.", cls="muted"),
+                Div(Label("Template name" if kind == KIND_PPTX else "Tool name"),
+                    Input(name="name", required=True,
+                          placeholder="e.g. corporate_16_9" if kind == KIND_PPTX
+                          else "e.g. formal_letter"),
+                    P("Letters, digits and underscores — this is the value passed as the "
+                      "'template' argument when generating a deck." if kind == KIND_PPTX
+                      else "Letters, digits and underscores — this is what the AI calls.",
+                      cls="muted"),
                     cls="field"),
-                Div(Label(f"{_KIND_LABEL[kind]} file ({_asset_ext(kind)})"),
-                    Input(name="file", type="file", accept=_asset_ext(kind), required=True),
+                Div(Label(f"{_KIND_LABEL[kind]} file ({_accept_exts(kind)})"),
+                    Input(name="file", type="file", accept=_accept_exts(kind), required=True),
                     cls="field"),
                 Button("Upload & analyze", type="submit", cls="btn btn-primary"),
                 action=ctx.u(f"/{kind}/draft"), method="post", enctype="multipart/form-data",
             ),
             cls="card",
         ),
-        Details(
+        _pptx_help() if kind == KIND_PPTX else Details(
             Summary("How does this work?"),
             P("Author your document in ",
               "Word" if kind == KIND_DOCX else "any HTML editor",
@@ -675,6 +982,26 @@ def _new_page(ctx: AdminContext, kind: str, csrf: str = "", error: str = None):
             P("When you upload, we scan the file, list every placeholder, and pre-build the "
               "argument form for you. Nothing goes live until you press Save.", cls="muted"),
         ),
+    )
+
+
+def _pptx_help():
+    """How a presentation template differs from the other two kinds."""
+    return Details(
+        Summary("How does this work?"),
+        P("A PowerPoint template is a ", Span("design", cls="chip"),
+          ", not a fill-in-the-blanks document. It has no placeholders and takes no "
+          "arguments: what it contributes is the slide master, the layouts, the theme "
+          "fonts and the colour palette."),
+        P("So this does not become a tool of its own, the way a Word template does. It "
+          "becomes one more choice for the ", Span("template", cls="chip"),
+          " argument of the presentation tool, alongside any others you register."),
+        P("Design your deck in PowerPoint and save it as .pptx or .potx. Every layout you "
+          "want used should carry the placeholders it needs — a title, a content box, a "
+          "picture frame — and we work out which slide role each layout plays from those. "
+          "Sample slides left in the file are dropped from generated decks.", cls="muted"),
+        P("When you upload, we report the slide size, every layout with the role we detected "
+          "for it, and the theme. Nothing goes live until you press Save.", cls="muted"),
     )
 
 
@@ -785,12 +1112,17 @@ def build_admin_app(mcp, config: Config) -> FastHTML:
         return _page(
             ctx, "Templates",
             H1("Templates"),
-            P("Create reusable Word and email templates. Each one becomes a tool the AI can call.",
+            P("Create reusable Word and email templates — each becomes a tool the AI can "
+              "call — and register PowerPoint templates for it to build decks on.",
               cls="muted"),
             Div(H2(f"{_KIND_ICON[KIND_DOCX]} Word templates"),
                 _template_table(ctx, KIND_DOCX, csrf), cls="card"),
             Div(H2(f"{_KIND_ICON[KIND_EMAIL]} Email templates"),
                 _template_table(ctx, KIND_EMAIL, csrf), cls="card"),
+            Div(H2(f"{_KIND_ICON[KIND_PPTX]} PowerPoint templates"),
+                P("Designs the presentation tool can build on. These are not tools of "
+                  "their own — they are choices for its 'template' argument.", cls="muted"),
+                _template_table(ctx, KIND_PPTX, csrf), cls="card"),
         )
 
     @rt("/status")
@@ -828,13 +1160,29 @@ def build_admin_app(mcp, config: Config) -> FastHTML:
         if any("Could not open" in w for w in analysis.warnings):
             return _new_page(ctx, kind, csrf=csrf, error=analysis.warnings[0])
 
-        filename = f"{name}{_asset_ext(kind)}"
-        ctx.store.write_asset(kind, filename, data)
-        spec = {"name": name, "description": "", _path_key(kind): filename, "args": []}
+        # Keep the uploaded extension (a .potx stays a .potx) rather than
+        # forcing the canonical one onto a file that is not in that format.
+        suffix = Path(getattr(upload, "filename", "") or "").suffix.lower()
+        if suffix not in kind_meta(kind)["asset_exts"]:
+            suffix = _asset_ext(kind)
+        filename = f"{name}{suffix}"
+        try:
+            ctx.store.write_asset(kind, filename, data)
+        except TemplateStoreError as e:
+            return _new_page(ctx, kind, csrf=csrf, error=str(e))
+        spec: Dict[str, Any] = {"name": name, "description": "", _path_key(kind): filename}
+        if kind == KIND_PPTX:
+            spec["strip_slides"] = True
+        else:
+            spec["args"] = []
         return _page(
             ctx, f"Configure {name}",
             H1(f"Configure {name}"),
-            _flash(f"Analyzed {filename} — review the arguments below, preview, then save.", "ok"),
+            _flash(
+                f"Analyzed {filename} — check the layouts below, preview a sample deck, "
+                "then save." if kind == KIND_PPTX else
+                f"Analyzed {filename} — review the arguments below, preview, then save.",
+                "ok"),
             _analysis_report(analysis, spec),
             _edit_form(ctx, kind, spec, analysis, is_new=False, csrf=csrf),
         )
@@ -920,8 +1268,21 @@ def build_admin_app(mcp, config: Config) -> FastHTML:
             return _page(ctx, "Save failed", H1("Save failed"), _flash(str(e), "err"),
                          A("← Back to all templates", href=ctx.u("/")))
         ok = ctx.register(kind, spec)
-        msg = (f"Saved — the tool '{spec['name']}' is now live and ready for the AI to use."
-               if ok else f"Saved, but the tool '{spec['name']}' could not be registered (check the logs).")
+        if kind == KIND_PPTX:
+            # No tool is created for a presentation template, so saying one is
+            # "live" would be a lie; what changed is the set of templates the
+            # presentation tool can build on.
+            msg = (
+                f"Saved — '{spec['name']}' is now one of the templates the presentation "
+                "tool can build on."
+                if ok else
+                f"Saved, but '{spec['name']}' did not come back out of the template "
+                "registry — check that its file is in custom_templates/ and see the logs."
+            )
+        else:
+            msg = (f"Saved — the tool '{spec['name']}' is now live and ready for the AI to use."
+                   if ok else
+                   f"Saved, but the tool '{spec['name']}' could not be registered (check the logs).")
         return _page(
             ctx, "Saved",
             H1("✓ Saved" if ok else "Saved with a warning"),
@@ -944,6 +1305,29 @@ def build_admin_app(mcp, config: Config) -> FastHTML:
         if not asset or not ctx.store.asset_exists(kind, asset):
             return HTMLResponse("<p>Nothing to preview yet — save the template first.</p>",
                                 status_code=400)
+        if kind == KIND_PPTX:
+            # Rendered from the file on disk, not from bytes: open_template needs
+            # a path to fall back to its .potx rewrite.
+            try:
+                out, warnings = render_pptx_preview(ctx.store.asset_path(kind, asset), spec)
+            except Exception as e:
+                logger.exception("[admin] pptx preview failed")
+                return HTMLResponse(f"<p>Could not build a preview: {e}</p>", status_code=400)
+            headers = {
+                "Content-Disposition": f'attachment; filename="{spec["name"]}_preview.pptx"',
+            }
+            if warnings:
+                # Surfaced in a header because the response body is the deck
+                # itself; the same warnings reach the model on a real call.
+                headers["X-Preview-Warnings"] = " | ".join(warnings)[:900]
+            return Response(
+                content=out,
+                media_type=(
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+                ),
+                headers=headers,
+            )
+
         data = ctx.store.read_asset(kind, asset)
         analysis = analyze(kind, data)
         values = sample_values(spec.get("args") or [], analysis.conditionals)

--- a/admin/preview.py
+++ b/admin/preview.py
@@ -12,6 +12,7 @@ dynamic email tool's pystache rendering.
 from __future__ import annotations
 
 import io
+from pathlib import Path
 from typing import Any, Dict, List
 
 import pystache
@@ -71,6 +72,91 @@ def render_docx_preview(
     out = io.BytesIO()
     doc.save(out)
     return out.getvalue()
+
+
+# A fixed sample deck, rendered through whatever template is being previewed.
+# Chosen to exercise the layouts an admin actually needs to check: the title
+# layout, a section divider, bulleted content, a two-column split, a drawn slide
+# that uses no placeholder at all, and the closing slide. Six slides keeps the
+# preview quick to open and quick to scan; a longer deck buries the problem.
+SAMPLE_DECK = [
+    {
+        "type": "title",
+        "title": "Quarterly Business Review",
+        "subtitle": "Sample deck — rendered through this template",
+    },
+    {"type": "section", "title": "Where we stand"},
+    {
+        "type": "content",
+        "title": "Highlights",
+        "body": (
+            "- Revenue **ahead of plan** for the third quarter running\n"
+            "- Churn down to 18%, the lowest since launch\n"
+            "  - Enterprise renewals carried most of the improvement\n"
+            "- One risk: onboarding time is still climbing"
+        ),
+    },
+    {
+        "type": "two_column",
+        "title": "What worked, what did not",
+        "left": {"heading": "Worked", "body": "- Partner channel\n- Pricing change"},
+        "right": {"heading": "Did not", "body": "- Self-serve funnel\n- Support backlog"},
+    },
+    {
+        "type": "kpi",
+        "title": "At a glance",
+        "items": [
+            {"value": "€4.2M", "label": "ARR", "delta": "+12% vs Q2"},
+            {"value": "18%", "label": "Churn", "delta": "−3pp"},
+            {"value": "94", "label": "NPS"},
+        ],
+    },
+    {
+        "type": "closing",
+        "title": "Thank you",
+        "subtitle": "Questions welcome",
+        "contact": ["hello@example.com"],
+    },
+]
+
+
+def render_pptx_preview(
+    template_path,
+    spec: Dict[str, Any],
+    slides: List[Dict[str, Any]] = None,
+) -> tuple:
+    """Build the sample deck on a PowerPoint template; return ``(bytes, warnings)``.
+
+    Goes through :class:`~pptx_tools.slide_builder.PowerpointPresentation` with a
+    spec built from the submitted form, so the preview exercises the same layout
+    resolution, role mapping and defaults the live tool will use — including any
+    layout overrides the admin has just typed but not yet saved. The warnings
+    the builder produces are handed back, because "which slides could not be
+    laid out on this template" is the single most useful thing a preview can
+    tell an admin.
+    """
+    from pptx_tools.slide_builder import PowerpointPresentation
+    from pptx_tools.templates import TemplateSpec, aspect_of, open_template
+
+    path = Path(template_path)
+    aspect = aspect_of(open_template(path))
+
+    template_spec = TemplateSpec(
+        name=str(spec.get("name") or "preview"),
+        path=path,
+        description=str(spec.get("description") or ""),
+        layouts=dict(spec.get("layouts") or {}),
+        defaults=dict(spec.get("defaults") or {}),
+        strip_slides=bool(spec.get("strip_slides", True)),
+        aspect=aspect,
+    )
+
+    presentation = PowerpointPresentation(
+        slides if slides is not None else SAMPLE_DECK,
+        format=aspect,
+        template_spec=template_spec,
+    )
+    return presentation.save().getvalue(), list(presentation.warnings)
 
 
 def render_email_preview(

--- a/admin/store.py
+++ b/admin/store.py
@@ -1,17 +1,24 @@
-"""Storage abstraction for UI-managed dynamic templates (docx + email).
+"""Storage abstraction for UI-managed dynamic templates (docx, email, pptx).
 
 The admin UI never edits the heavily-documented master YAML files
-(``config/docx_templates.yaml`` / ``config/email_templates.yaml``). Instead each
-UI-managed template is persisted as a **single file per template** in a sibling
-directory:
+(``config/docx_templates.yaml`` and friends). Instead each UI-managed template
+is persisted as a **single file per template** in a sibling directory:
 
     config/docx_templates.d/<name>.yaml      + custom_templates/<docx_path>
     config/email_templates.d/<name>.yaml     + custom_templates/<html_path>
+    config/pptx_templates.d/<name>.yaml      + custom_templates/<pptx_path>
 
 The loader (see :mod:`docx_tools.dynamic_docx_tools` /
-:mod:`email_tools.dynamic_email_tools`) merges these per-template files on top of
-the master YAML, so the master files stay pristine and UI edits produce clean,
-reviewable diffs.
+:mod:`email_tools.dynamic_email_tools` / :mod:`pptx_tools.templates`) merges
+these per-template files on top of the master YAML, so the master files stay
+pristine and UI edits produce clean, reviewable diffs.
+
+The three kinds share this storage but not their meaning. A docx or email
+template is a *parameterised document*: it declares ``args`` and becomes one
+MCP tool of its own. A pptx template is a *design* — layouts, theme, aspect —
+with no arguments at all; it becomes one more value for the ``template``
+argument of the single ``create_powerpoint_presentation`` tool. The store does
+not care about that difference, but the views do.
 
 Everything goes through the :class:`TemplateStore` interface. The default
 :class:`FileTemplateStore` reads/writes the mounted volume; a future
@@ -35,12 +42,30 @@ logger = logging.getLogger(__name__)
 # Supported template kinds.
 KIND_DOCX = "docx"
 KIND_EMAIL = "email"
+KIND_PPTX = "pptx"
 
-# Per-kind metadata: where managed spec files live, the asset extension, and the
-# spec key that names the asset file.
-_KIND_META: Dict[str, Dict[str, str]] = {
-    KIND_DOCX: {"subdir": "docx_templates.d", "asset_ext": ".docx", "path_key": "docx_path"},
-    KIND_EMAIL: {"subdir": "email_templates.d", "asset_ext": ".html", "path_key": "html_path"},
+# Per-kind metadata: where managed spec files live, the accepted asset
+# extensions, and the spec key that names the asset file. ``asset_ext`` is the
+# canonical extension (used when deriving a filename from the template name);
+# ``asset_exts`` is everything accepted on upload.
+#
+# PowerPoint is the only kind with more than one: a designer's brand deck
+# routinely arrives as a .potx, and pptx_tools.templates.open_template already
+# rewrites that content type in memory rather than rejecting it. Refusing the
+# upload here would put back the wall that code exists to remove.
+_KIND_META: Dict[str, Dict[str, Any]] = {
+    KIND_DOCX: {
+        "subdir": "docx_templates.d", "asset_ext": ".docx",
+        "asset_exts": (".docx",), "path_key": "docx_path",
+    },
+    KIND_EMAIL: {
+        "subdir": "email_templates.d", "asset_ext": ".html",
+        "asset_exts": (".html",), "path_key": "html_path",
+    },
+    KIND_PPTX: {
+        "subdir": "pptx_templates.d", "asset_ext": ".pptx",
+        "asset_exts": (".pptx", ".potx"), "path_key": "pptx_path",
+    },
 }
 
 # Tool names must be safe identifiers — they become MCP tool names and file
@@ -65,7 +90,17 @@ def valid_kind(kind: str) -> bool:
     return kind in _KIND_META
 
 
-def _require_kind(kind: str) -> Dict[str, str]:
+def kind_meta(kind: str) -> Dict[str, Any]:
+    """A copy of *kind*'s metadata: ``subdir``, ``asset_ext``, ``asset_exts``,
+    ``path_key``.
+
+    The views ask for this rather than carrying their own per-kind ternaries,
+    so adding a kind means editing one table.
+    """
+    return dict(_require_kind(kind))
+
+
+def _require_kind(kind: str) -> Dict[str, Any]:
     meta = _KIND_META.get(kind)
     if meta is None:
         raise TemplateStoreError(f"Unknown template kind: {kind!r}")
@@ -96,9 +131,10 @@ def validate_asset_filename(filename: str, kind: str) -> str:
         raise TemplateStoreError(
             f"Asset filename must be a bare filename (no directories); got {filename!r}."
         )
-    if p.suffix.lower() != meta["asset_ext"]:
+    accepted = meta["asset_exts"]
+    if p.suffix.lower() not in accepted:
         raise TemplateStoreError(
-            f"{kind} asset must end with {meta['asset_ext']}; got {filename!r}."
+            f"{kind} asset must end with {' or '.join(accepted)}; got {filename!r}."
         )
     return filename
 

--- a/pptx_tools/slide_builder.py
+++ b/pptx_tools/slide_builder.py
@@ -44,7 +44,7 @@ from .chart_utils import (
 )
 from .layouts import LayoutResolver, role_for_slide
 from .schema import Bullet, coerce_slides
-from .templates import open_template, select_template
+from .templates import TemplateSpec, open_template, select_template
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,8 @@ class PowerpointPresentation(SlideHelpers):
                  footer_text: Optional[str] = None,
                  show_slide_numbers: bool = False,
                  language: Optional[str] = None,
-                 template: Optional[str] = None):
+                 template: Optional[str] = None,
+                 template_spec: Optional[TemplateSpec] = None):
         """Initialize and build presentation.
 
         Args:
@@ -72,6 +73,12 @@ class PowerpointPresentation(SlideHelpers):
             language: BCP-47 tag (e.g. "cs-CZ") stamped on every text run so
                 the deck is proof-read in the right language.
             template: Name of a registered template. Overrides *format*.
+            template_spec: An already-resolved template to build on, bypassing
+                the registry lookup. Overrides *template*. This exists for the
+                admin UI's preview, which must render a template the admin has
+                uploaded but not yet saved — going through the registry would
+                mean either finding nothing or writing the entry before the
+                admin has agreed to it.
         """
         if not slides:
             raise ValueError("At least one slide is required")
@@ -85,7 +92,7 @@ class PowerpointPresentation(SlideHelpers):
         )
 
         self.spec = None
-        self.presentation = self._create_presentation(format, template)
+        self.presentation = self._create_presentation(format, template, template_spec)
         self._layouts = LayoutResolver(
             self.presentation, self.spec.layouts if self.spec else None
         )
@@ -118,7 +125,8 @@ class PowerpointPresentation(SlideHelpers):
         self.warnings.append(entry)
         logger.warning("[pptx] %s", entry)
 
-    def _create_presentation(self, format: str, template: Optional[str] = None) -> Presentation:
+    def _create_presentation(self, format: str, template: Optional[str] = None,
+                             template_spec: Optional[TemplateSpec] = None) -> Presentation:
         """Create the presentation from the selected registered template."""
         if format not in VALID_SLIDE_FORMATS:
             logger.warning(
@@ -130,7 +138,10 @@ class PowerpointPresentation(SlideHelpers):
             )
             format = DEFAULT_SLIDE_FORMAT
 
-        spec, note = select_template(template, None if template else format)
+        if template_spec is not None:
+            spec, note = template_spec, None
+        else:
+            spec, note = select_template(template, None if template else format)
         if note:
             self.warnings.append(note)
 

--- a/pptx_tools/slide_builder.py
+++ b/pptx_tools/slide_builder.py
@@ -213,7 +213,20 @@ class PowerpointPresentation(SlideHelpers):
         template carrying a sample slide shipped that slide's XML, text and
         images inside every generated file even though PowerPoint showed the
         right slide count. Dropping the relationship removes the part too.
+
+        A template can opt out with ``strip_slides: false`` when its own slides
+        are meant to survive — a fixed cover or back page the generated slides
+        should follow. Until this check existed the option was parsed, stored
+        and offered in the admin UI but never read, so unticking the box
+        changed nothing and said nothing.
         """
+        if self.spec is not None and not self.spec.strip_slides:
+            logger.debug(
+                "Template %r sets strip_slides: false; keeping its %d slide(s)",
+                self.spec.name, len(self.presentation.slides._sldIdLst),
+            )
+            return
+
         sldIdLst = self.presentation.slides._sldIdLst
         prs_part = self.presentation.part
 

--- a/tests/test_admin_pptx.py
+++ b/tests/test_admin_pptx.py
@@ -9,6 +9,7 @@ import asyncio
 import io
 import re
 import sys
+import tempfile
 import zipfile
 from pathlib import Path
 
@@ -17,6 +18,7 @@ sys.path.insert(0, str(project_root))
 
 import pytest
 from pptx import Presentation as PptxReader
+from pptx.oxml.ns import qn as pptx_qn
 from starlette.testclient import TestClient
 
 import admin.store as store_mod
@@ -35,6 +37,26 @@ TEMPLATE_4_3 = project_root / "default_templates" / "default_pptx_template_4_3.p
 @pytest.fixture
 def pptx_bytes():
     return TEMPLATE_16_9.read_bytes()
+
+
+def _template_with_a_duplicate_role() -> bytes:
+    """A template where two layouts classify as the same role.
+
+    Neither shipped template has one: their eight detected layouts map one to
+    one onto the eight roles, so first-wins and last-wins tie-breaking are
+    indistinguishable on them. Turning a vertical-text layout horizontal gives
+    it the TITLE+BODY signature of a section header — which is precisely the
+    collision ``_is_vertical`` exists to prevent — and so produces the tie a
+    tie-breaking test needs.
+    """
+    prs = PptxReader(str(TEMPLATE_16_9))
+    for placeholder in prs.slide_layouts[9].placeholders:      # 'Nadpis a svislý text'
+        body_pr = placeholder.text_frame._txBody.find(pptx_qn("a:bodyPr"))
+        if body_pr is not None and body_pr.get("vert"):
+            body_pr.set("vert", "horz")
+    buf = io.BytesIO()
+    prs.save(buf)
+    return buf.getvalue()
 
 
 def _as_potx(data: bytes) -> bytes:
@@ -147,6 +169,57 @@ class TestAnalyzePptx:
     def test_layout_names_drive_the_role_dropdowns(self, pptx_bytes):
         a = analyze_pptx(pptx_bytes)
         assert a.layout_names == [layout.name for layout in a.layouts]
+
+    @pytest.mark.parametrize("path", [TEMPLATE_16_9, TEMPLATE_4_3])
+    def test_the_reported_role_map_is_what_the_builder_will_actually_use(self, path):
+        """The UI's claim must match the resolver's behaviour, not merely resemble it.
+
+        Both pick the first layout classifying as each role, but that is two
+        separate implementations of the same rule in two modules. If either
+        side's tie-breaking drifts, the admin page would report a mapping the
+        tool does not honour — worse than reporting nothing, because it looks
+        authoritative.
+        """
+        from pptx_tools.layouts import ROLES, LayoutResolver
+        from pptx_tools.templates import open_template
+
+        reported = analyze_pptx(path.read_bytes()).role_map
+        resolver = LayoutResolver(open_template(path))
+
+        for role in ROLES:
+            layout, warning = resolver.resolve(role)
+            if role in reported:
+                assert reported[role] == layout.name, f"{role} disagrees"
+                assert warning is None, f"{role} resolved with a warning: {warning}"
+            else:
+                # A role the UI reports as missing must be one the resolver
+                # cannot satisfy either — it falls back by position and says so.
+                assert warning is not None, f"{role} was omitted but resolves cleanly"
+
+    def test_a_contested_role_reports_the_layout_the_resolver_picks(self):
+        """The agreement test above cannot see tie-breaking; this one can.
+
+        On the shipped templates every detected role has exactly one layout, so
+        first-wins and last-wins agree and a divergence would go unnoticed. With
+        two layouts claiming ``section``, only the earlier one is correct.
+        """
+        from pptx_tools.layouts import LayoutResolver
+        from pptx_tools.templates import open_template
+
+        data = _template_with_a_duplicate_role()
+        analysis = analyze_pptx(data)
+
+        claimants = [layout.name for layout in analysis.layouts if layout.role == "section"]
+        assert len(claimants) == 2, "fixture no longer produces a contested role"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tie.pptx"
+            path.write_bytes(data)
+            layout, warning = LayoutResolver(open_template(path)).resolve("section")
+
+        assert analysis.role_map["section"] == claimants[0]
+        assert analysis.role_map["section"] == layout.name
+        assert warning is None
 
 
 # =============================================================================

--- a/tests/test_admin_pptx.py
+++ b/tests/test_admin_pptx.py
@@ -1,0 +1,443 @@
+"""Admin UI support for PowerPoint templates (Phase 3b).
+
+A presentation template is not the same kind of thing as a Word or email
+template — it declares no arguments and becomes no tool of its own — so most of
+what these tests assert is that the pptx path says and does something different
+from the other two, rather than reusing machinery that would be meaningless.
+"""
+import asyncio
+import io
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import pytest
+from pptx import Presentation as PptxReader
+from starlette.testclient import TestClient
+
+import admin.store as store_mod
+import metrics
+import pptx_tools.templates as templates_mod
+import template_utils as tu
+from admin.analysis import PptxAnalysis, analyze, analyze_pptx
+from admin.preview import SAMPLE_DECK, render_pptx_preview
+from admin.store import KIND_PPTX, TemplateStoreError, kind_meta, validate_asset_filename
+from config import Config
+
+TEMPLATE_16_9 = project_root / "default_templates" / "default_pptx_template_16_9.pptx"
+TEMPLATE_4_3 = project_root / "default_templates" / "default_pptx_template_4_3.pptx"
+
+
+@pytest.fixture
+def pptx_bytes():
+    return TEMPLATE_16_9.read_bytes()
+
+
+def _as_potx(data: bytes) -> bytes:
+    """Rewrite a .pptx into the .potx content type, as PowerPoint would."""
+    src = io.BytesIO(data)
+    out = io.BytesIO()
+    with zipfile.ZipFile(src) as zin, zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            blob = zin.read(item.filename)
+            if item.filename == "[Content_Types].xml":
+                blob = blob.decode("utf-8").replace(
+                    "presentationml.presentation.main+xml",
+                    "presentationml.template.main+xml",
+                ).encode("utf-8")
+            zout.writestr(item, blob)
+    return out.getvalue()
+
+
+# =============================================================================
+# Store
+# =============================================================================
+
+class TestStoreKind:
+
+    def test_pptx_is_a_known_kind(self):
+        meta = kind_meta(KIND_PPTX)
+        assert meta["subdir"] == "pptx_templates.d"
+        assert meta["path_key"] == "pptx_path"
+
+    def test_potx_is_accepted_alongside_pptx(self):
+        """A designer's brand deck routinely arrives as a .potx."""
+        assert validate_asset_filename("brand.pptx", KIND_PPTX) == "brand.pptx"
+        assert validate_asset_filename("brand.potx", KIND_PPTX) == "brand.potx"
+
+    def test_a_wrong_extension_is_still_refused(self):
+        with pytest.raises(TemplateStoreError):
+            validate_asset_filename("brand.docx", KIND_PPTX)
+
+    def test_a_pptx_is_not_accepted_for_the_docx_kind(self):
+        with pytest.raises(TemplateStoreError):
+            validate_asset_filename("brand.pptx", "docx")
+
+    def test_directory_traversal_is_refused(self):
+        with pytest.raises(TemplateStoreError):
+            validate_asset_filename("../../etc/brand.pptx", KIND_PPTX)
+
+
+# =============================================================================
+# Analysis
+# =============================================================================
+
+class TestAnalyzePptx:
+
+    def test_reports_aspect_and_slide_size(self, pptx_bytes):
+        a = analyze_pptx(pptx_bytes)
+        assert a.aspect == "16:9"
+        assert "13.33" in a.slide_size
+
+    def test_four_three_template_reads_as_four_three(self):
+        assert analyze_pptx(TEMPLATE_4_3.read_bytes()).aspect == "4:3"
+
+    def test_every_layout_is_listed_with_its_placeholders(self, pptx_bytes):
+        a = analyze_pptx(pptx_bytes)
+        assert len(a.layouts) == len(PptxReader(str(TEMPLATE_16_9)).slide_layouts)
+        title = [layout for layout in a.layouts if layout.role == "title"][0]
+        assert "CENTER_TITLE" in title.placeholders
+        assert "SUBTITLE" in title.placeholders
+
+    def test_roles_are_detected_for_the_shipped_template(self, pptx_bytes):
+        """The shipped deck covers every role, so nothing falls back by position."""
+        a = analyze_pptx(pptx_bytes)
+        assert a.missing_roles == []
+        assert set(a.role_map) >= {"title", "section", "content", "two_column", "blank"}
+
+    def test_theme_fonts_and_colours_are_read(self, pptx_bytes):
+        """Regression: the theme is a generic Part with no parsed element.
+
+        Reaching for ``_element`` returned None and silently produced an empty
+        palette — a feature that looks present and does nothing.
+        """
+        a = analyze_pptx(pptx_bytes)
+        assert a.theme_fonts.get("body")
+        assert a.theme_colors.get("accent1", "").startswith("#")
+        assert len(a.theme_colors["accent1"]) == 7
+
+    def test_system_colours_resolve_through_last_clr(self, pptx_bytes):
+        """dk1/lt1 are sysClr, not srgbClr; without lastClr they read as blank."""
+        colors = analyze_pptx(pptx_bytes).theme_colors
+        assert colors.get("dk1") == "#000000"
+        assert colors.get("lt1") == "#FFFFFF"
+
+    def test_unrecognised_layouts_are_reported_not_guessed(self, pptx_bytes):
+        """Vertical-text and content-with-caption are deliberate refusals."""
+        a = analyze_pptx(pptx_bytes)
+        unrecognised = [layout.name for layout in a.layouts if layout.role is None]
+        assert unrecognised
+        assert any("match no known role" in w for w in a.warnings)
+
+    def test_a_potx_is_analysed_like_a_pptx(self, pptx_bytes):
+        assert analyze_pptx(_as_potx(pptx_bytes)).aspect == "16:9"
+
+    def test_a_file_that_is_not_a_presentation_warns_rather_than_raising(self):
+        a = analyze_pptx(b"this is not a presentation")
+        assert any("Could not open" in w for w in a.warnings)
+        assert a.layouts == []
+
+    def test_dispatch_by_kind_returns_the_pptx_shape(self, pptx_bytes):
+        assert isinstance(analyze("pptx", pptx_bytes), PptxAnalysis)
+
+    def test_layout_names_drive_the_role_dropdowns(self, pptx_bytes):
+        a = analyze_pptx(pptx_bytes)
+        assert a.layout_names == [layout.name for layout in a.layouts]
+
+
+# =============================================================================
+# Preview
+# =============================================================================
+
+class TestPptxPreview:
+
+    def test_builds_the_sample_deck_on_the_template(self):
+        data, warnings = render_pptx_preview(TEMPLATE_16_9, {"name": "brand"})
+        doc = PptxReader(io.BytesIO(data))
+        assert len(doc.slides) == len(SAMPLE_DECK)
+        assert warnings == []
+
+    def test_each_slide_lands_on_the_layout_its_role_asks_for(self):
+        data, _ = render_pptx_preview(TEMPLATE_16_9, {"name": "brand"})
+        doc = PptxReader(io.BytesIO(data))
+        # title, section, content: the three roles with an unambiguous layout.
+        assert doc.slides[0].slide_layout.name == "Úvodní snímek"
+        assert doc.slides[1].slide_layout.name == "Záhlaví oddílu"
+        assert doc.slides[2].slide_layout.name == "Nadpis a obsah"
+
+    def test_an_unsaved_layout_override_is_honoured(self):
+        """The whole point of previewing before saving."""
+        data, _ = render_pptx_preview(
+            TEMPLATE_16_9, {"name": "brand", "layouts": {"content": "Obsah s titulkem"}}
+        )
+        doc = PptxReader(io.BytesIO(data))
+        assert doc.slides[2].slide_layout.name == "Obsah s titulkem"
+
+    def test_defaults_are_applied_to_the_preview(self):
+        data, _ = render_pptx_preview(
+            TEMPLATE_16_9,
+            {"name": "brand", "defaults": {"footer_text": "ACME · Confidential"}},
+        )
+        doc = PptxReader(io.BytesIO(data))
+        text = "\n".join(
+            shape.text_frame.text
+            for shape in doc.slides[2].shapes if shape.has_text_frame
+        )
+        assert "ACME · Confidential" in text
+
+    def test_the_preview_follows_the_templates_own_aspect(self):
+        data, _ = render_pptx_preview(TEMPLATE_4_3, {"name": "legacy"})
+        doc = PptxReader(io.BytesIO(data))
+        assert doc.slide_width < doc.slide_height * 1.45
+
+    def test_template_sample_slides_do_not_leak_into_the_preview(self):
+        data, _ = render_pptx_preview(TEMPLATE_16_9, {"name": "brand"})
+        assert len(PptxReader(io.BytesIO(data)).slides) == len(SAMPLE_DECK)
+
+
+# =============================================================================
+# Admin routes
+# =============================================================================
+
+@pytest.fixture
+def admin_client(tmp_path, monkeypatch):
+    """A logged-in client whose store *and* pptx registry live under tmp_path."""
+    custom = tmp_path / "custom"
+    cfg = tmp_path / "config"
+    custom.mkdir()
+    cfg.mkdir()
+
+    monkeypatch.setattr(store_mod, "_APP_CUSTOM_DIR", tmp_path / "nope_custom")
+    monkeypatch.setattr(store_mod, "_APP_CONFIG_DIR", tmp_path / "nope_config")
+    monkeypatch.setattr(store_mod, "_LOCAL_CUSTOM_DIR", custom)
+    monkeypatch.setattr(store_mod, "_LOCAL_CONFIG_DIR", cfg)
+    monkeypatch.setattr(tu, "APP_CUSTOM_DIR", tmp_path / "nope_custom")
+    monkeypatch.setattr(tu, "LOCAL_CUSTOM_DIR", custom)
+    # The pptx registry resolves its config dir independently of the store.
+    monkeypatch.setattr(templates_mod, "_APP_CONFIG_DIR", tmp_path / "nope_config")
+    monkeypatch.setattr(templates_mod, "_LOCAL_CONFIG_DIR", cfg)
+    templates_mod.clear_cache()
+
+    monkeypatch.setenv("ADMIN_ENABLED", "true")
+    monkeypatch.setenv("ADMIN_PASSWORD", "pw")
+    monkeypatch.delenv("API_KEY", raising=False)
+
+    from fastmcp import FastMCP
+    from admin.app import build_combined_app
+
+    mcp = FastMCP("test-admin-pptx")
+    client = TestClient(build_combined_app(mcp, Config.from_env()))
+    metrics.reset()
+    client.__enter__()
+    client.post("/admin/login", data={"password": "pw"})
+    yield client, cfg, custom, mcp
+    client.__exit__(None, None, None)
+    metrics.reset()
+    templates_mod.clear_cache()
+
+
+def _tool_names(mcp) -> list:
+    """The MCP tools currently registered, from a synchronous test body."""
+    return sorted(t.name for t in asyncio.run(mcp.list_tools()))
+
+
+def _csrf(client) -> str:
+    html = client.get("/admin/new/pptx").text
+    tag = re.search(r'<input[^>]*name="csrf"[^>]*>', html)
+    assert tag, "no CSRF input found"
+    return re.search(r'value="([^"]*)"', tag.group(0)).group(1)
+
+
+def _post(client, url, data=None, files=None):
+    payload = dict(data or {})
+    payload["csrf"] = _csrf(client)
+    return client.post(url, data=payload, files=files)
+
+
+class TestAdminRoutes:
+
+    def test_the_index_lists_a_powerpoint_section(self, admin_client):
+        client, _cfg, _custom, _mcp = admin_client
+        html = client.get("/admin/").text
+        assert "PowerPoint templates" in html
+
+    def test_the_new_page_explains_it_is_a_design_not_a_tool(self, admin_client):
+        """The distinction the whole phase turns on; say it where it matters."""
+        client, _cfg, _custom, _mcp = admin_client
+        html = client.get("/admin/new/pptx").text
+        assert "design" in html
+        assert ".pptx,.potx" in html
+
+    def test_upload_reports_the_layouts_and_offers_role_overrides(self, admin_client, pptx_bytes):
+        client, _cfg, custom, _mcp = admin_client
+        r = _post(client, "/admin/pptx/draft", data={"name": "brand"},
+                  files={"file": ("brand.pptx", pptx_bytes,
+                                  "application/vnd.openxmlformats-officedocument"
+                                  ".presentationml.presentation")})
+        assert r.status_code == 200
+        assert "Úvodní snímek" in r.text          # a real layout name
+        assert "layout_title" in r.text            # the role dropdown
+        assert "Aptos" in r.text                   # theme font
+        assert (custom / "brand.pptx").is_file()
+
+    def test_the_upload_form_offers_no_arguments(self, admin_client, pptx_bytes):
+        """A presentation template takes none; offering the editor would lie."""
+        client, _cfg, _custom, _mcp = admin_client
+        r = _post(client, "/admin/pptx/draft", data={"name": "brand"},
+                  files={"file": ("brand.pptx", pptx_bytes, "application/vnd.ms-powerpoint")})
+        assert "Add argument" not in r.text
+        assert 'name="arg_name"' not in r.text
+
+    def test_a_potx_upload_keeps_its_extension(self, admin_client, pptx_bytes):
+        client, _cfg, custom, _mcp = admin_client
+        r = _post(client, "/admin/pptx/draft", data={"name": "brand"},
+                  files={"file": ("brand.potx", _as_potx(pptx_bytes),
+                                  "application/vnd.openxmlformats-officedocument"
+                                  ".presentationml.template")})
+        assert r.status_code == 200
+        assert (custom / "brand.potx").is_file()
+        assert not (custom / "brand.pptx").exists()
+
+    def test_a_file_that_is_not_a_presentation_is_rejected(self, admin_client):
+        client, _cfg, custom, _mcp = admin_client
+        r = _post(client, "/admin/pptx/draft", data={"name": "brand"},
+                  files={"file": ("brand.pptx", b"not a deck", "application/octet-stream")})
+        assert "Could not open" in r.text
+        assert not (custom / "brand.pptx").exists()
+
+    def test_saving_writes_a_spec_the_registry_picks_up(self, admin_client, pptx_bytes):
+        client, cfg, custom, _mcp = admin_client
+        (custom / "brand.pptx").write_bytes(pptx_bytes)
+
+        r = _post(client, "/admin/pptx/save", data={
+            "name": "brand", "asset_filename": "brand.pptx",
+            "description": "Brand deck", "is_default": "1", "strip_slides": "1",
+            "layout_content": "Obsah s titulkem",
+            "default_footer_text": "ACME · Confidential",
+            "default_language": "cs-CZ", "default_slide_numbers": "1",
+        })
+        assert r.status_code == 200
+
+        spec_file = cfg / "pptx_templates.d" / "brand.yaml"
+        assert spec_file.is_file()
+        import yaml
+        spec = yaml.safe_load(spec_file.read_text())
+        assert spec["pptx_path"] == "brand.pptx"
+        assert spec["default"] is True
+        assert spec["layouts"] == {"content": "Obsah s titulkem"}
+        assert spec["defaults"] == {
+            "footer_text": "ACME · Confidential",
+            "language": "cs-CZ",
+            "show_slide_numbers": True,
+        }
+
+    def test_a_saved_template_becomes_usable_without_a_restart(self, admin_client, pptx_bytes):
+        """"Live" for pptx means the registry re-read it, not that a tool exists."""
+        client, _cfg, custom, _mcp = admin_client
+        (custom / "brand.pptx").write_bytes(pptx_bytes)
+        assert "brand" not in templates_mod.template_names()
+
+        _post(client, "/admin/pptx/save",
+              data={"name": "brand", "asset_filename": "brand.pptx", "strip_slides": "1"})
+
+        assert "brand" in templates_mod.template_names()
+
+    def test_saving_does_not_create_an_mcp_tool(self, admin_client, pptx_bytes):
+        """One presentation tool exists; templates are its argument, not tools.
+
+        A Word template of the same name would appear in the tool list. This
+        asserts against the live MCP tool registry, not against page text.
+        """
+        client, _cfg, custom, mcp = admin_client
+        (custom / "brand.pptx").write_bytes(pptx_bytes)
+
+        names_before = _tool_names(mcp)
+        _post(client, "/admin/pptx/save",
+              data={"name": "brand", "asset_filename": "brand.pptx", "strip_slides": "1"})
+
+        assert _tool_names(mcp) == names_before
+        assert "brand" not in _tool_names(mcp)
+
+    def test_the_save_message_does_not_promise_a_tool(self, admin_client, pptx_bytes):
+        client, _cfg, custom, _mcp = admin_client
+        (custom / "brand.pptx").write_bytes(pptx_bytes)
+        r = _post(client, "/admin/pptx/save",
+                  data={"name": "brand", "asset_filename": "brand.pptx", "strip_slides": "1"})
+
+        assert "one of the templates the presentation tool can build on" in r.text
+        assert "is now live and ready for the AI to use" not in r.text
+
+    def test_saving_with_no_uploaded_file_is_refused_outright(self, admin_client):
+        """The store refuses before the registry is ever consulted."""
+        client, cfg, _custom, _mcp = admin_client
+        r = _post(client, "/admin/pptx/save",
+                  data={"name": "ghost", "asset_filename": "ghost.pptx", "strip_slides": "1"})
+
+        assert "Save failed" in r.text
+        assert "does not exist yet" in r.text
+        assert not (cfg / "pptx_templates.d" / "ghost.yaml").exists()
+
+    def test_a_spec_the_registry_cannot_resolve_is_not_called_live(self):
+        """The store and the registry search different directory sets.
+
+        A file present to the store but absent from the template search path is
+        a misconfiguration, not a success — the admin must not be told the
+        template is usable when the tool will not find it.
+        """
+        from admin.app import AdminContext
+
+        templates_mod.clear_cache()
+        assert AdminContext._refresh_pptx_registry("definitely_not_registered") is False
+
+    def test_unticked_checkboxes_are_recorded_as_off(self, admin_client, pptx_bytes):
+        """An HTML checkbox sends nothing when unticked; absence must mean False."""
+        client, cfg, custom, _mcp = admin_client
+        (custom / "brand.pptx").write_bytes(pptx_bytes)
+        _post(client, "/admin/pptx/save",
+              data={"name": "brand", "asset_filename": "brand.pptx"})
+
+        import yaml
+        spec = yaml.safe_load((cfg / "pptx_templates.d" / "brand.yaml").read_text())
+        assert spec["strip_slides"] is False
+        assert "default" not in spec
+        assert "defaults" not in spec
+
+    def test_preview_returns_a_deck(self, admin_client, pptx_bytes):
+        client, _cfg, custom, _mcp = admin_client
+        (custom / "brand.pptx").write_bytes(pptx_bytes)
+        r = _post(client, "/admin/pptx/preview",
+                  data={"name": "brand", "asset_filename": "brand.pptx", "strip_slides": "1"})
+
+        assert r.status_code == 200
+        assert "presentationml.presentation" in r.headers["content-type"]
+        assert len(PptxReader(io.BytesIO(r.content)).slides) == len(SAMPLE_DECK)
+
+    def test_editing_shows_what_was_saved(self, admin_client, pptx_bytes):
+        client, _cfg, custom, _mcp = admin_client
+        (custom / "brand.pptx").write_bytes(pptx_bytes)
+        _post(client, "/admin/pptx/save", data={
+            "name": "brand", "asset_filename": "brand.pptx",
+            "description": "Brand deck", "layout_content": "Obsah s titulkem",
+            "default_language": "cs-CZ", "strip_slides": "1",
+        })
+        html = client.get("/admin/pptx/brand/edit").text
+        assert "Brand deck" in html
+        assert "cs-CZ" in html
+        assert 'value="Obsah s titulkem" selected' in html
+
+    def test_deleting_removes_it_from_the_registry(self, admin_client, pptx_bytes):
+        client, _cfg, custom, _mcp = admin_client
+        (custom / "brand.pptx").write_bytes(pptx_bytes)
+        _post(client, "/admin/pptx/save",
+              data={"name": "brand", "asset_filename": "brand.pptx", "strip_slides": "1"})
+        assert "brand" in templates_mod.template_names()
+
+        _post(client, "/admin/pptx/brand/delete")
+
+        assert "brand" not in templates_mod.template_names()
+        # The source file is kept, matching the other kinds.
+        assert (custom / "brand.pptx").is_file()

--- a/tests/test_admin_pptx.py
+++ b/tests/test_admin_pptx.py
@@ -19,13 +19,14 @@ sys.path.insert(0, str(project_root))
 import pytest
 from pptx import Presentation as PptxReader
 from pptx.oxml.ns import qn as pptx_qn
+from lxml import etree
 from starlette.testclient import TestClient
 
 import admin.store as store_mod
 import metrics
 import pptx_tools.templates as templates_mod
 import template_utils as tu
-from admin.analysis import PptxAnalysis, analyze, analyze_pptx
+from admin.analysis import PptxAnalysis, _read_theme, analyze, analyze_pptx
 from admin.preview import SAMPLE_DECK, render_pptx_preview
 from admin.store import KIND_PPTX, TemplateStoreError, kind_meta, validate_asset_filename
 from config import Config
@@ -148,6 +149,31 @@ class TestAnalyzePptx:
         assert colors.get("dk1") == "#000000"
         assert colors.get("lt1") == "#FFFFFF"
 
+    def test_an_unconvertible_colour_node_is_logged_not_dropped_silently(self, caplog):
+        """OOXML permits scrgbClr/hslClr; Office writes neither, but say so.
+
+        Dropping an unreadable entry without a word is the failure this reader
+        was written to avoid — it just happens to be a narrower input space.
+        """
+        import logging
+
+        prs = PptxReader(str(TEMPLATE_16_9))
+        theme = prs.slide_masters[0].part.part_related_by(
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme")
+        root = etree.fromstring(theme.blob)
+        accent1 = root.find(".//" + pptx_qn("a:clrScheme") + "/" + pptx_qn("a:accent1"))
+        for child in list(accent1):
+            accent1.remove(child)
+        etree.SubElement(accent1, pptx_qn("a:scrgbClr"), r="50000", g="50000", b="50000")
+        theme._blob = etree.tostring(root)
+
+        with caplog.at_level(logging.INFO, logger="admin.analysis"):
+            fonts, colors = _read_theme(prs)
+
+        assert "accent1" not in colors
+        assert "accent2" in colors, "the other entries must still be read"
+        assert any("scrgbClr" in record.getMessage() for record in caplog.records)
+
     def test_unrecognised_layouts_are_reported_not_guessed(self, pptx_bytes):
         """Vertical-text and content-with-caption are deliberate refusals."""
         a = analyze_pptx(pptx_bytes)
@@ -220,6 +246,66 @@ class TestAnalyzePptx:
         assert analysis.role_map["section"] == claimants[0]
         assert analysis.role_map["section"] == layout.name
         assert warning is None
+
+
+# =============================================================================
+# strip_slides
+# =============================================================================
+
+def _template_carrying_its_own_slide(tmp_path) -> Path:
+    """A template file with a sample slide of its own, as a designer might leave."""
+    prs = PptxReader(str(TEMPLATE_16_9))
+    slide = prs.slides.add_slide(prs.slide_layouts[0])
+    slide.shapes.title.text = "SAMPLE COVER"
+    path = tmp_path / "with_sample.pptx"
+    prs.save(str(path))
+    return path
+
+
+def _build_on(path, strip_slides: bool):
+    from pptx_tools.slide_builder import PowerpointPresentation
+    from pptx_tools.templates import TemplateSpec, aspect_of, open_template
+
+    spec = TemplateSpec(name="sampled", path=Path(path), strip_slides=strip_slides,
+                        aspect=aspect_of(open_template(Path(path))))
+    pres = PowerpointPresentation(
+        [{"type": "content", "title": "Generated", "body": "- something"}],
+        "16:9", template_spec=spec,
+    )
+    doc = PptxReader(pres.save())
+    texts = [shape.text_frame.text for slide in doc.slides
+             for shape in slide.shapes if shape.has_text_frame]
+    return doc, texts
+
+
+class TestStripSlides:
+    """The admin checkbox has to change the deck, not just the YAML.
+
+    Found in review: `strip_slides` was parsed into the spec and offered in the
+    UI, but `_remove_template_slides` ran unconditionally and nothing ever read
+    the field. Unticking the box changed nothing and said nothing — the same
+    silent-failure class as the theme reader this phase already fixed. The
+    round-trip test alone could not see it, because it only checked the YAML.
+    """
+
+    def test_enabled_drops_the_templates_own_slides(self, tmp_path):
+        doc, texts = _build_on(_template_carrying_its_own_slide(tmp_path), True)
+        assert len(doc.slides) == 1
+        assert not any("SAMPLE COVER" in t for t in texts)
+
+    def test_disabled_keeps_them_ahead_of_the_generated_slides(self, tmp_path):
+        doc, texts = _build_on(_template_carrying_its_own_slide(tmp_path), False)
+        assert len(doc.slides) == 2
+        assert "SAMPLE COVER" in doc.slides[0].shapes.title.text
+        assert any("Generated" in t for t in texts)
+
+    def test_with_no_template_spec_the_previous_behaviour_is_unchanged(self):
+        """The built-in-theme path has no spec to consult and must still strip."""
+        from pptx_tools.slide_builder import PowerpointPresentation
+
+        pres = PowerpointPresentation(
+            [{"type": "content", "title": "Generated", "body": "- x"}], "16:9")
+        assert len(PptxReader(pres.save()).slides) == 1
 
 
 # =============================================================================

--- a/tests/test_template_store.py
+++ b/tests/test_template_store.py
@@ -110,5 +110,7 @@ def test_email_asset_extension_enforced():
 
 
 def test_unknown_kind_raises(store):
+    # "pptx" used to stand in for an unknown kind here; it is a supported kind
+    # now, so this needs one that genuinely is not.
     with pytest.raises(TemplateStoreError):
-        store.list_specs("pptx")
+        store.list_specs("keynote")


### PR DESCRIPTION
Part of #96 and #100. Completes #100 — this is the admin-UI half I split out of #104.

| Stack | Issue | Status |
|---|---|---|
| Phase 0 — stop the bleeding | #97 | merged in #101 |
| Phase 1 — typed slide schema | #98 | merged in #102 |
| Phase 2 — template registry | #99 | merged in #103 |
| Phase 3 — new slide types | #100 | merged in #104 |
| **Phase 3b — admin UI for pptx templates** | #100 | **this PR** |

Registers, analyses, previews and deletes `.pptx` / `.potx` templates through the same admin UI that already manages Word and email templates.

## A PowerPoint template is not the same kind of thing

This is the decision the whole PR turns on, so it is worth stating plainly.

A Word or email template is a **parameterised document**: it declares `args`, and each one becomes an MCP tool of its own. A PowerPoint template is a **design** — slide master, layouts, theme fonts, palette — with no placeholders and no arguments. It does not become a tool. It becomes one more value for the `template` argument of the single `create_powerpoint_presentation` tool.

Reusing the existing machinery would have produced a page that lies: an argument editor for something that takes no arguments, and a "your tool is now live" message for a tool that was never created. So the pptx path branches where the meaning differs and shares everything where it does not:

| | docx / email | pptx |
|---|---|---|
| Form body | argument editor | layout roles + deck defaults |
| "Live" means | the MCP tool is registered | the template registry has re-read the spec |
| Preview | substitutes sample values | builds a fixed six-slide sample deck |
| Save message | "the tool … is now live" | "…is now one of the templates the presentation tool can build on" |

Chrome, storage, CSRF, upload limits, re-upload and delete are all shared.

## What the page does

**Upload** a `.pptx` or a `.potx`. Phase 2's `open_template` already rewrites the template content type in memory, so refusing a designer's `.potx` here would have put back the wall that code exists to remove. Per-kind metadata now carries a *tuple* of accepted extensions, and the uploaded extension is preserved rather than forced to the canonical one.

**Analysis** reports what actually decides how a generated deck looks — slide size and aspect, every layout with its placeholder signature and auto-detected role, and the theme fonts and palette. It warns about the things that genuinely spoil a deck: a role no layout covers (those slides fall back by position), layouts with no footer placeholder, sample slides left in the file, and layouts matching no known role.

`analyze_pptx` returns its own dataclass rather than the docx `Analysis`, sharing only the `warnings` field the common view code touches. Forcing a design into a placeholders-and-conditionals shape would have meant a report of empty lists.

**Layout overrides** are dropdowns populated from the template's real layout names, each showing the auto-detected choice as its default option and flagging any role nothing matches.

**Preview** builds a six-slide sample deck through the real `PowerpointPresentation`, so layout resolution, role mapping and defaults are exercised exactly as a live call would exercise them. It honours overrides the admin has typed but not yet saved — which is the point of previewing before saving, and which needed a `template_spec` seam on the builder: going through the registry would mean either finding nothing, or writing the entry before the admin has agreed to it.

## Three bugs found and fixed

**1. The theme reader silently returned an empty palette.** python-pptx has no model class for a theme, so the relationship resolves to a generic `Part` with no `_element` — my first version reached for one, got `None`, and produced no fonts and no colours **with no error**. It would have shipped as a feature that looks present and quietly does nothing. Now it parses the part's raw blob. Tested, along with the `sysClr`/`lastClr` path that `dk1` and `lt1` need.

**2. `strip_slides` never stripped anything** (found in review, 37054eb). The field was parsed into `TemplateSpec` back in #103 and documented as an option in `config/pptx_templates.yaml`, and this branch put a checkbox in front of it — but `_remove_template_slides()` ran unconditionally and nothing anywhere read it. Confirmed by building on a template carrying its own slide: with the option off the sample was stripped anyway, identically to on.

That is the same silent-failure class as (1), and my own round-trip test could not see it because it only asserted the form value reached the YAML. Wired rather than removed: the option is documented in a file users read, and keeping a template's own cover ahead of the generated slides is a real use.

```
strip_slides=True  -> slides=1  ['Generated', 'x']
strip_slides=False -> slides=2  ['SAMPLE COVER', 'Generated', 'x']
no spec at all     -> slides=1                        # built-in theme, unchanged
```

**3. Unreadable theme colour nodes vanished without a word.** OOXML permits `scrgbClr` and `hslClr` in a colour scheme; Office writes neither, but dropping an entry in silence is the failure this reader exists to avoid. Now logged.

## Verification

```
1217 passed, 5 deselected     # full suite, network excluded
5 passed                      # the network-marked tests, run separately
All checks passed!            # ruff
```

45 tests in `tests/test_admin_pptx.py`: the store kind, analysis against both shipped templates, `strip_slides` behaviour through the real builder, preview output, and the admin routes driven end to end through a `TestClient`.

**Ten behaviours were mutation-checked** — each broken in turn, with the corresponding test confirmed to fail. That process caught two of my own tests proving nothing:

- A test pinning the admin role map to the resolver's choice passed just as happily with the tie-breaking reversed, because both shipped templates map eight layouts one-to-one onto eight roles. It is now paired with a second test built on a template that *does* have a contested role — made by turning a vertical-text layout horizontal, the exact collision `_is_vertical` exists to prevent — which the same mutation fails.
- The `strip_slides` round-trip test, which the reviewer caught rather than the mutation pass: it checked the YAML, never the deck.

Other corrections made rather than worked around: my sample deck used a `contacts` key the schema does not have (`extra="forbid"` caught it); one test asserted a registry-miss message that is unreachable because `save_spec` refuses earlier — an *earlier and better* failure than the one I had hypothesised, so the test now asserts reality and the registry-miss path is covered where it is actually reachable.

One existing test used `"pptx"` as its exemplar *unknown* kind and now uses one that genuinely is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYtbUgysFugzG2h8dhnKU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYtbUgysFugzG2h8dhnKU1)_