### PR TITLE
ci(cd): do not move the `latest` image tag on a prerelease

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,8 +39,11 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          # A prerelease must not become `latest`: everyone pulling the default
+          # tag would get the beta. `latest` moves only on a full release; the
+          # expression yields an empty line otherwise, which the action ignores.
           tags: |
             georgx22/mcp-office-docs:${{ github.event.release.tag_name }}
-            georgx22/mcp-office-docs:latest
+            ${{ !github.event.release.prerelease && 'georgx22/mcp-office-docs:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Found while preparing the first beta prerelease of the PowerPoint work (#96).

`.github/workflows/cd.yml` runs on every *published* release and tagged the image as both `:<tag>` and `:latest` unconditionally. A prerelease publishes too, so cutting a beta would have handed the beta to everyone pulling the default tag.

`latest` now moves only when the release is not a prerelease:

```yaml
tags: |
  georgx22/mcp-office-docs:${{ github.event.release.tag_name }}
  ${{ !github.event.release.prerelease && 'georgx22/mcp-office-docs:latest' || '' }}
```

The expression yields an empty line for a prerelease, which `docker/build-push-action` ignores. YAML validated locally; no other change.

This has to land before the beta is tagged: the `release` workflow runs from the tagged commit's own workflow file, so a tag on the current master would still run the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYtbUgysFugzG2h8dhnKU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYtbUgysFugzG2h8dhnKU1)_